### PR TITLE
Feature/fix junit deprecations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to radixdlt-java
+# Contributing to radixdlt
 
 ### Table of contents
 - [Code of conduct](#code-of-conduct)

--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,6 @@ subprojects {
             dependency 'org.powermock:powermock-module-junit4:2.0.7'
             dependency 'org.powermock:powermock-api-mockito2:2.0.7'
             dependency 'nl.jqno.equalsverifier:equalsverifier:3.4.2'
-            dependency 'org.hamcrest:hamcrest-library:1.3'
             dependency 'org.assertj:assertj-core:3.11.1'
             dependency 'junit:junit:4.13.1'
 

--- a/radixdlt-core/radixdlt/build.gradle
+++ b/radixdlt-core/radixdlt/build.gradle
@@ -149,7 +149,6 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4'
     testImplementation 'org.powermock:powermock-api-mockito2'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier'
-    testImplementation 'org.hamcrest:hamcrest-library'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'com.flipkart.zjsonpatch:zjsonpatch'
     testImplementation 'org.reflections:reflections'

--- a/radixdlt-core/radixdlt/src/main/java/org/radix/database/DatabaseEnvironment.java
+++ b/radixdlt-core/radixdlt/src/main/java/org/radix/database/DatabaseEnvironment.java
@@ -30,8 +30,6 @@ import com.sleepycat.je.EnvironmentConfig;
 import com.sleepycat.je.LockMode;
 import com.sleepycat.je.OperationStatus;
 import com.sleepycat.je.Transaction;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.bouncycastle.util.Arrays;
 
 import java.io.File;
@@ -39,8 +37,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
 public final class DatabaseEnvironment {
-	private static final Logger log = LogManager.getLogger();
-
 	private final ReentrantLock lock = new ReentrantLock(true);
 	private Database metaDatabase;
 	private Environment environment = null;

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/bft/BFTValidatorSetTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/bft/BFTValidatorSetTest.java
@@ -49,8 +49,9 @@ public class BFTValidatorSetTest {
 	public void sensibleToString() {
 		BFTNode node = BFTNode.create(ECKeyPair.generateNew().getPublicKey());
 		String s = BFTValidatorSet.from(ImmutableList.of(BFTValidator.from(node, UInt256.ONE))).toString();
-		assertThat(s).contains(BFTValidatorSet.class.getSimpleName());
-		assertThat(s).contains(node.getSimpleName());
+		assertThat(s)
+			.contains(BFTValidatorSet.class.getSimpleName())
+			.contains(node.getSimpleName());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/bft/BFTValidatorSetTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/bft/BFTValidatorSetTest.java
@@ -32,11 +32,10 @@ import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.crypto.HashUtils;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BFTValidatorSetTest {
 
@@ -50,15 +49,15 @@ public class BFTValidatorSetTest {
 	public void sensibleToString() {
 		BFTNode node = BFTNode.create(ECKeyPair.generateNew().getPublicKey());
 		String s = BFTValidatorSet.from(ImmutableList.of(BFTValidator.from(node, UInt256.ONE))).toString();
-		assertThat(s, containsString(BFTValidatorSet.class.getSimpleName()));
-		assertThat(s, containsString(node.getSimpleName()));
+		assertThat(s).contains(BFTValidatorSet.class.getSimpleName());
+		assertThat(s).contains(node.getSimpleName());
 	}
 
 	@Test
 	public void testStreamConstructor() {
 		BFTNode node = BFTNode.create(ECKeyPair.generateNew().getPublicKey());
 		String s = BFTValidatorSet.from(ImmutableList.of(BFTValidator.from(node, UInt256.ONE)).stream()).toString();
-		assertThat(s, containsString(node.getSimpleName()));
+		assertThat(s).contains(node.getSimpleName());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/bft/BFTValidatorTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/bft/BFTValidatorTest.java
@@ -22,10 +22,9 @@ import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BFTValidatorTest {
 	@Test
@@ -37,7 +36,7 @@ public class BFTValidatorTest {
 	@Test
 	public void sensibleToString() {
 		String s = create().toString();
-		assertThat(s, containsString(BFTValidator.class.getSimpleName()));
+		assertThat(s).contains(BFTValidator.class.getSimpleName());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/bft/ValidationStateTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/bft/ValidationStateTest.java
@@ -17,12 +17,13 @@
 
 package com.radixdlt.consensus.bft;
 
-import com.radixdlt.utils.UInt256;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.*;
+import com.radixdlt.utils.UInt256;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -36,7 +37,7 @@ public class ValidationStateTest {
 	@Test
 	public void sensibleToString() {
 		String s = BFTValidatorSet.from(ImmutableList.of()).newValidationState().toString();
-		assertThat(s, containsString(ValidationState.class.getSimpleName()));
+		assertThat(s).contains(ValidationState.class.getSimpleName());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/mempool/LocalMempoolTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/mempool/LocalMempoolTest.java
@@ -153,8 +153,9 @@ public class LocalMempoolTest {
 
 		String tostring = this.mempool.toString();
 
-		assertThat(tostring).contains("1/2");
-		assertThat(tostring).contains(LocalMempool.class.getSimpleName());
+		assertThat(tostring)
+			.contains("1/2")
+			.contains(LocalMempool.class.getSimpleName());
 	}
 
 	private static Command makeCommand(int n) {

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/mempool/LocalMempoolTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/mempool/LocalMempoolTest.java
@@ -31,7 +31,7 @@ import com.radixdlt.utils.Ints;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LocalMempoolTest {
 	private LocalMempool mempool;
@@ -153,8 +153,8 @@ public class LocalMempoolTest {
 
 		String tostring = this.mempool.toString();
 
-		assertThat(tostring, containsString("1/2"));
-		assertThat(tostring, containsString(LocalMempool.class.getSimpleName()));
+		assertThat(tostring).contains("1/2");
+		assertThat(tostring).contains(LocalMempool.class.getSimpleName());
 	}
 
 	private static Command makeCommand(int n) {

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/mempool/SharedMempoolTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/mempool/SharedMempoolTest.java
@@ -29,9 +29,8 @@ import com.google.common.collect.Sets;
 import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.utils.Ints;
 
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SharedMempoolTest {
 	private static final HashCode TEST_HASH = makeHash(1234);
@@ -90,8 +89,8 @@ public class SharedMempoolTest {
 
 		String tostring = this.sharedMempool.toString();
 
-		assertThat(tostring, containsString("1/2"));
-		assertThat(tostring, containsString(SharedMempool.class.getSimpleName()));
+		assertThat(tostring).contains("1/2");
+		assertThat(tostring).contains(SharedMempool.class.getSimpleName());
 	}
 
 	private static HashCode makeHash(int n) {

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/mempool/SharedMempoolTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/mempool/SharedMempoolTest.java
@@ -89,8 +89,9 @@ public class SharedMempoolTest {
 
 		String tostring = this.sharedMempool.toString();
 
-		assertThat(tostring).contains("1/2");
-		assertThat(tostring).contains(SharedMempool.class.getSimpleName());
+		assertThat(tostring)
+			.contains("1/2")
+			.contains(SharedMempool.class.getSimpleName());
 	}
 
 	private static HashCode makeHash(int n) {

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/mempool/SubmissionControlImplTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/mempool/SubmissionControlImplTest.java
@@ -40,9 +40,9 @@ import com.radixdlt.engine.RadixEngine;
 import com.radixdlt.serialization.Serialization;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-import static org.hamcrest.Matchers.*;
 
 public class SubmissionControlImplTest {
 
@@ -123,7 +123,7 @@ public class SubmissionControlImplTest {
 			this.submissionControl.submitAtom(mock(JSONObject.class, illegalStateAnswer()), a -> called.set(true));
 			fail();
 		} catch (IllegalArgumentException e) {
-			assertThat(called.get(), is(false));
+			assertThat(called.get()).isFalse();
 			verify(this.sender, never()).sendDeserializeFailure(any(), any());
 			verify(this.sender, never()).sendRadixEngineFailure(any(), any());
 			verify(this.mempool, never()).add(any());
@@ -157,7 +157,7 @@ public class SubmissionControlImplTest {
 	@Test
 	public void sensible_tostring() {
 		String tostring = this.submissionControl.toString();
-		assertThat(tostring, containsString(this.submissionControl.getClass().getSimpleName()));
+		assertThat(tostring).contains(this.submissionControl.getClass().getSimpleName());
 	}
 
     private static <T> T throwingMock(Class<T> classToMock) {

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/ConsensusEventMessageTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/ConsensusEventMessageTest.java
@@ -37,8 +37,10 @@ public class ConsensusEventMessageTest {
 		Proposal m = mock(Proposal.class);
 		ConsensusEventMessage msg1 = new ConsensusEventMessage(0, m);
 		String s1 = msg1.toString();
-		assertThat(s1).contains(ConsensusEventMessage.class.getSimpleName());
-		assertThat(s1).contains(m.toString());
+
+		assertThat(s1)
+			.contains(ConsensusEventMessage.class.getSimpleName())
+			.contains(m.toString());
 
 		assertTrue(msg1.getConsensusMessage() instanceof Proposal);
 	}
@@ -48,8 +50,9 @@ public class ConsensusEventMessageTest {
 		Vote m = mock(Vote.class);
 		ConsensusEventMessage msg1 = new ConsensusEventMessage(0, m);
 		String s1 = msg1.toString();
-		assertThat(s1).contains(ConsensusEventMessage.class.getSimpleName());
-		assertThat(s1).contains(m.toString());
+		assertThat(s1)
+			.contains(ConsensusEventMessage.class.getSimpleName())
+			.contains(m.toString());
 
 		assertTrue(msg1.getConsensusMessage() instanceof Vote);
 	}
@@ -58,8 +61,9 @@ public class ConsensusEventMessageTest {
 	public void sensibleToStringNone() {
 		ConsensusEventMessage msg1 = new ConsensusEventMessage();
 		String s1 = msg1.toString();
-		assertThat(s1).contains(ConsensusEventMessage.class.getSimpleName());
-		assertThat(s1).contains("null");
+		assertThat(s1)
+			.contains(ConsensusEventMessage.class.getSimpleName())
+			.contains("null");
 	}
 
 	@Test(expected = IllegalStateException.class)

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/ConsensusEventMessageTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/ConsensusEventMessageTest.java
@@ -26,9 +26,9 @@ import org.junit.Test;
 import com.radixdlt.consensus.Proposal;
 import com.radixdlt.consensus.Vote;
 
-import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConsensusEventMessageTest {
 
@@ -37,8 +37,8 @@ public class ConsensusEventMessageTest {
 		Proposal m = mock(Proposal.class);
 		ConsensusEventMessage msg1 = new ConsensusEventMessage(0, m);
 		String s1 = msg1.toString();
-		assertThat(s1, containsString(ConsensusEventMessage.class.getSimpleName()));
-		assertThat(s1, containsString(m.toString()));
+		assertThat(s1).contains(ConsensusEventMessage.class.getSimpleName());
+		assertThat(s1).contains(m.toString());
 
 		assertTrue(msg1.getConsensusMessage() instanceof Proposal);
 	}
@@ -48,8 +48,8 @@ public class ConsensusEventMessageTest {
 		Vote m = mock(Vote.class);
 		ConsensusEventMessage msg1 = new ConsensusEventMessage(0, m);
 		String s1 = msg1.toString();
-		assertThat(s1, containsString(ConsensusEventMessage.class.getSimpleName()));
-		assertThat(s1, containsString(m.toString()));
+		assertThat(s1).contains(ConsensusEventMessage.class.getSimpleName());
+		assertThat(s1).contains(m.toString());
 
 		assertTrue(msg1.getConsensusMessage() instanceof Vote);
 	}
@@ -58,8 +58,8 @@ public class ConsensusEventMessageTest {
 	public void sensibleToStringNone() {
 		ConsensusEventMessage msg1 = new ConsensusEventMessage();
 		String s1 = msg1.toString();
-		assertThat(s1, containsString(ConsensusEventMessage.class.getSimpleName()));
-		assertThat(s1, containsString("null"));
+		assertThat(s1).contains(ConsensusEventMessage.class.getSimpleName());
+		assertThat(s1).contains("null");
 	}
 
 	@Test(expected = IllegalStateException.class)

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetEpochRequestMessageTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetEpochRequestMessageTest.java
@@ -17,9 +17,8 @@
 
 package com.radixdlt.middleware2.network;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.hash.HashCode;
 import com.radixdlt.consensus.bft.BFTNode;
@@ -33,7 +32,7 @@ public class GetEpochRequestMessageTest {
 	public void sensibleToString() {
 		GetEpochRequestMessage msg = new GetEpochRequestMessage(mock(BFTNode.class), 12345, 1);
 		String s1 = msg.toString();
-		assertThat(s1, containsString(GetEpochRequestMessage.class.getSimpleName()));
+		assertThat(s1).contains(GetEpochRequestMessage.class.getSimpleName());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetEpochResponseMessageTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetEpochResponseMessageTest.java
@@ -17,9 +17,8 @@
 
 package com.radixdlt.middleware2.network;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.hash.HashCode;
 import com.radixdlt.consensus.VerifiedLedgerHeaderAndProof;
@@ -35,7 +34,7 @@ public class GetEpochResponseMessageTest {
 		VerifiedLedgerHeaderAndProof ancestor = mock(VerifiedLedgerHeaderAndProof.class);
 		GetEpochResponseMessage msg = new GetEpochResponseMessage(mock(BFTNode.class), 12345, ancestor);
 		String s1 = msg.toString();
-		assertThat(s1, containsString(GetEpochResponseMessage.class.getSimpleName()));
+		assertThat(s1).contains(GetEpochResponseMessage.class.getSimpleName());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesErrorResponseMessageTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesErrorResponseMessageTest.java
@@ -17,8 +17,7 @@
 
 package com.radixdlt.middleware2.network;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -44,7 +43,7 @@ public class GetVerticesErrorResponseMessageTest {
 		HighQC highQC = HighQC.from(qc, qc, Optional.empty());
 		GetVerticesErrorResponseMessage msg1 = new GetVerticesErrorResponseMessage(0, highQC);
 		String s1 = msg1.toString();
-		assertThat(s1, containsString(GetVerticesErrorResponseMessage.class.getSimpleName()));
+		assertThat(s1).contains(GetVerticesErrorResponseMessage.class.getSimpleName());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesRequestMessageTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesRequestMessageTest.java
@@ -17,8 +17,7 @@
 
 package com.radixdlt.middleware2.network;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.hash.HashCode;
 import com.radixdlt.crypto.HashUtils;
@@ -32,8 +31,8 @@ public class GetVerticesRequestMessageTest {
 		HashCode vertexId = HashUtils.random256();
 		GetVerticesRequestMessage msg1 = new GetVerticesRequestMessage(0, vertexId, 1);
 		String s1 = msg1.toString();
-		assertThat(s1, containsString(GetVerticesRequestMessage.class.getSimpleName()));
-		assertThat(s1, containsString(vertexId.toString()));
+		assertThat(s1).contains(GetVerticesRequestMessage.class.getSimpleName());
+		assertThat(s1).contains(vertexId.toString());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesRequestMessageTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesRequestMessageTest.java
@@ -31,8 +31,9 @@ public class GetVerticesRequestMessageTest {
 		HashCode vertexId = HashUtils.random256();
 		GetVerticesRequestMessage msg1 = new GetVerticesRequestMessage(0, vertexId, 1);
 		String s1 = msg1.toString();
-		assertThat(s1).contains(GetVerticesRequestMessage.class.getSimpleName());
-		assertThat(s1).contains(vertexId.toString());
+		assertThat(s1)
+			.contains(GetVerticesRequestMessage.class.getSimpleName())
+			.contains(vertexId.toString());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesResponseMessageTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesResponseMessageTest.java
@@ -17,9 +17,8 @@
 
 package com.radixdlt.middleware2.network;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.HashCode;
@@ -35,8 +34,8 @@ public class GetVerticesResponseMessageTest {
 		UnverifiedVertex genesisVertex = mock(UnverifiedVertex.class);
 		GetVerticesResponseMessage msg1 = new GetVerticesResponseMessage(0, ImmutableList.of(genesisVertex));
 		String s1 = msg1.toString();
-		assertThat(s1, containsString(GetVerticesResponseMessage.class.getSimpleName()));
-		assertThat(s1, containsString(genesisVertex.toString()));
+		assertThat(s1).contains(GetVerticesResponseMessage.class.getSimpleName());
+		assertThat(s1).contains(genesisVertex.toString());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesResponseMessageTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesResponseMessageTest.java
@@ -34,8 +34,9 @@ public class GetVerticesResponseMessageTest {
 		UnverifiedVertex genesisVertex = mock(UnverifiedVertex.class);
 		GetVerticesResponseMessage msg1 = new GetVerticesResponseMessage(0, ImmutableList.of(genesisVertex));
 		String s1 = msg1.toString();
-		assertThat(s1).contains(GetVerticesResponseMessage.class.getSimpleName());
-		assertThat(s1).contains(genesisVertex.toString());
+		assertThat(s1)
+			.contains(GetVerticesResponseMessage.class.getSimpleName())
+			.contains(genesisVertex.toString());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/AddressBookEventsTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/AddressBookEventsTest.java
@@ -23,9 +23,9 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 
-import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Basic tests for implementors of {@link AddressBookEvent}.
@@ -56,7 +56,7 @@ public class AddressBookEventsTest {
 		assertSame(mockedPeer, nonEmptyEvent.peers().get(0));
 
 		String s = nonEmptyEvent.toString();
-		assertThat(s, startsWith(cls.getSimpleName() + "["));
-		assertThat(s, containsString(mockedPeer.toString()));
+		assertThat(s).startsWith(cls.getSimpleName() + "[");
+		assertThat(s).contains(mockedPeer.toString());
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/PeerWithNidTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/PeerWithNidTest.java
@@ -50,8 +50,9 @@ public class PeerWithNidTest {
 	public void testToString() {
 		String s = this.pwn.toString();
 
-		assertThat(s).contains("PeerWithNid"); // class name
-		assertThat(s).contains(this.nid.toString()); // nid
+		assertThat(s)
+			.contains("PeerWithNid") // class name
+			.contains(this.nid.toString()); // nid
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/PeerWithNidTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/PeerWithNidTest.java
@@ -32,7 +32,7 @@ import com.radixdlt.network.transport.TransportException;
 import com.radixdlt.network.transport.TransportInfo;
 
 import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 // Retaining these tests, even though PeerWithNid has moved into tests
 public class PeerWithNidTest {
@@ -50,29 +50,29 @@ public class PeerWithNidTest {
 	public void testToString() {
 		String s = this.pwn.toString();
 
-		assertThat(s, containsString("PeerWithNid")); // class name
-		assertThat(s, containsString(this.nid.toString())); // nid
+		assertThat(s).contains("PeerWithNid"); // class name
+		assertThat(s).contains(this.nid.toString()); // nid
 	}
 
 	@Test
 	public void testGetNID() {
-		assertThat(this.pwn.getNID(), is(this.nid));
+		assertThat(this.pwn.getNID()).isEqualTo(this.nid);
 	}
 
 	@Test
 	public void testHasNID() {
-		assertThat(this.pwn.hasNID(), is(true));
+		assertThat(this.pwn.hasNID()).isTrue();
 	}
 
 	@Test
 	public void testSupportsTransport() {
-		assertThat(this.pwn.supportsTransport("ANY"), is(false));
+		assertThat(this.pwn.supportsTransport("ANY")).isFalse();
 	}
 
 	@Test
 	public void testSupportedTransports() {
 		ImmutableList<TransportInfo> tis = this.pwn.supportedTransports().collect(ImmutableList.toImmutableList());
-		assertThat(tis, empty());
+		assertThat(tis).isEmpty();
 	}
 
 	@Test(expected = TransportException.class)
@@ -83,28 +83,28 @@ public class PeerWithNidTest {
 
 	@Test
 	public void testHasSystem() {
-		assertThat(this.pwn.hasSystem(), is(false));
+		assertThat(this.pwn.hasSystem()).isFalse();
 	}
 
 	@Test
 	public void testGetSystem() {
-		assertThat(this.pwn.getSystem(), nullValue());
+		assertThat(this.pwn.getSystem()).isNull();
 	}
 
 	@Test
 	public void testBan() {
 		long now = Time.currentTimestamp();
 		this.pwn.ban("Reason for ban");
-		assertThat(this.pwn.getTimestamp(Timestamps.BANNED), greaterThanOrEqualTo(now));
-		assertThat(this.pwn.getBanReason(), is("Reason for ban"));
+		assertThat(this.pwn.getTimestamp(Timestamps.BANNED)).isGreaterThanOrEqualTo(now);
+		assertThat(this.pwn.getBanReason()).isEqualTo("Reason for ban");
 	}
 
 	@Test
 	public void testBanCopy() {
 		long now = Time.currentTimestamp();
 		this.pwn.setBan("Reason for ban", now);
-		assertThat(this.pwn.getTimestamp(Timestamps.BANNED), is(now));
-		assertThat(this.pwn.getBanReason(), is("Reason for ban"));
+		assertThat(this.pwn.getTimestamp(Timestamps.BANNED)).isEqualTo(now);
+		assertThat(this.pwn.getBanReason()).isEqualTo("Reason for ban");
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/PeerWithSystemTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/PeerWithSystemTest.java
@@ -36,7 +36,7 @@ import com.radixdlt.network.transport.udp.UDPConstants;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PeerWithSystemTest {
 
@@ -59,9 +59,9 @@ public class PeerWithSystemTest {
 	public void testToString() {
 		String s = this.pws.toString();
 
-		assertThat(s, containsString("PeerWithSystem")); // class name
-		assertThat(s, containsString(this.nid.toString())); // nid
-		assertThat(s, containsString("{}"));
+		assertThat(s).contains("PeerWithSystem"); // class name
+		assertThat(s).contains(this.nid.toString()); // nid
+		assertThat(s).contains("{}");
 
 		EUID localNid = EUID.TWO;
 		TransportInfo fakeUdp = TransportInfo.of(UDPConstants.NAME,
@@ -75,37 +75,37 @@ public class PeerWithSystemTest {
 		when(localSystem.getNID()).thenReturn(localNid);
 		PeerWithSystem localPws = new PeerWithSystem(localSystem);
 		String s2 = localPws.toString();
-		assertThat(s2, containsString("PeerWithSystem")); // class name
-		assertThat(s2, containsString(localNid.toString())); // nid
-		assertThat(s2, containsString(fakeUdp.metadata().get(UDPConstants.METADATA_HOST)));
-		assertThat(s2, containsString(fakeUdp.metadata().get(UDPConstants.METADATA_PORT)));
+		assertThat(s2).contains("PeerWithSystem"); // class name
+		assertThat(s2).contains(localNid.toString()); // nid
+		assertThat(s2).contains(fakeUdp.metadata().get(UDPConstants.METADATA_HOST));
+		assertThat(s2).contains(fakeUdp.metadata().get(UDPConstants.METADATA_PORT));
 	}
 
 	@Test
 	public void testGetNID() {
-		assertThat(this.pws.getNID(), is(this.nid));
+		assertThat(this.pws.getNID()).isEqualTo(this.nid);
 	}
 
 	@Test
 	public void testHasNID() {
-		assertThat(this.pws.hasNID(), is(true));
+		assertThat(this.pws.hasNID()).isTrue();
 	}
 
 	@Test
 	public void testSupportsTransport() {
-		assertThat(this.pws.supportsTransport("NONESUCH"), is(false));
-		assertThat(this.pws.supportsTransport(this.dummy.name()), is(true));
+		assertThat(this.pws.supportsTransport("NONESUCH")).isFalse();
+		assertThat(this.pws.supportsTransport(this.dummy.name())).isTrue();
 	}
 
 	@Test
 	public void testSupportedTransports() {
 		ImmutableList<TransportInfo> tis = this.pws.supportedTransports().collect(ImmutableList.toImmutableList());
-		assertThat(tis, contains(this.dummy));
+		assertThat(tis).contains(this.dummy);
 	}
 
 	@Test
 	public void testConnectionData() {
-		assertThat(this.pws.connectionData(this.dummy.name()), is(this.dummy.metadata()));
+		assertThat(this.pws.connectionData(this.dummy.name())).isEqualTo(this.dummy.metadata());
 	}
 
 	@Test(expected = TransportException.class)
@@ -116,12 +116,12 @@ public class PeerWithSystemTest {
 
 	@Test
 	public void testHasSystem() {
-		assertThat(this.pws.hasSystem(), is(true));
+		assertThat(this.pws.hasSystem()).isTrue();
 	}
 
 	@Test
 	public void testGetSystem() {
-		assertThat(this.pws.getSystem(), sameInstance(this.system));
+		assertThat(this.pws.getSystem()).isSameAs(this.system);
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/PeerWithSystemTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/PeerWithSystemTest.java
@@ -59,9 +59,10 @@ public class PeerWithSystemTest {
 	public void testToString() {
 		String s = this.pws.toString();
 
-		assertThat(s).contains("PeerWithSystem"); // class name
-		assertThat(s).contains(this.nid.toString()); // nid
-		assertThat(s).contains("{}");
+		assertThat(s)
+			.contains("PeerWithSystem") // class name
+			.contains(this.nid.toString()) // nid
+			.contains("{}");
 
 		EUID localNid = EUID.TWO;
 		TransportInfo fakeUdp = TransportInfo.of(UDPConstants.NAME,
@@ -75,10 +76,11 @@ public class PeerWithSystemTest {
 		when(localSystem.getNID()).thenReturn(localNid);
 		PeerWithSystem localPws = new PeerWithSystem(localSystem);
 		String s2 = localPws.toString();
-		assertThat(s2).contains("PeerWithSystem"); // class name
-		assertThat(s2).contains(localNid.toString()); // nid
-		assertThat(s2).contains(fakeUdp.metadata().get(UDPConstants.METADATA_HOST));
-		assertThat(s2).contains(fakeUdp.metadata().get(UDPConstants.METADATA_PORT));
+		assertThat(s2)
+			.contains("PeerWithSystem") // class name
+			.contains(localNid.toString()) // nid
+			.contains(fakeUdp.metadata().get(UDPConstants.METADATA_HOST))
+			.contains(fakeUdp.metadata().get(UDPConstants.METADATA_PORT));
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/PeerWithTransportTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/PeerWithTransportTest.java
@@ -48,8 +48,9 @@ public class PeerWithTransportTest {
 	public void testToString() {
 		String s = this.pwt.toString();
 
-		assertThat(s).contains("PeerWithTransport"); // class name
-		assertThat(s).contains(this.dummy.name()); // transport name
+		assertThat(s)
+			.contains("PeerWithTransport") // class name
+			.contains(this.dummy.name()); // transport name
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/PeerWithTransportTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/addressbook/PeerWithTransportTest.java
@@ -31,7 +31,7 @@ import com.radixdlt.network.transport.TransportException;
 import com.radixdlt.network.transport.TransportInfo;
 
 import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PeerWithTransportTest {
 
@@ -48,35 +48,35 @@ public class PeerWithTransportTest {
 	public void testToString() {
 		String s = this.pwt.toString();
 
-		assertThat(s, containsString("PeerWithTransport")); // class name
-		assertThat(s, containsString(this.dummy.name())); // transport name
+		assertThat(s).contains("PeerWithTransport"); // class name
+		assertThat(s).contains(this.dummy.name()); // transport name
 	}
 
 	@Test
 	public void testGetNID() {
-		assertThat(this.pwt.getNID(), is(EUID.ZERO));
+		assertThat(this.pwt.getNID()).isEqualTo(EUID.ZERO);
 	}
 
 	@Test
 	public void testHasNID() {
-		assertThat(this.pwt.hasNID(), is(false));
+		assertThat(this.pwt.hasNID()).isFalse();
 	}
 
 	@Test
 	public void testSupportsTransport() {
-		assertThat(this.pwt.supportsTransport("NOTEXIST"), is(false));
-		assertThat(this.pwt.supportsTransport(this.dummy.name()), is(true));
+		assertThat(this.pwt.supportsTransport("NOTEXIST")).isFalse();
+		assertThat(this.pwt.supportsTransport(this.dummy.name())).isTrue();
 	}
 
 	@Test
 	public void testSupportedTransports() {
 		ImmutableList<TransportInfo> tis = this.pwt.supportedTransports().collect(ImmutableList.toImmutableList());
-		assertThat(tis, contains(this.dummy));
+		assertThat(tis).contains(this.dummy);
 	}
 
 	@Test
 	public void testConnectionData() {
-		assertThat(this.pwt.connectionData("DUMMY"), is(this.dummy.metadata()));
+		assertThat(this.pwt.connectionData("DUMMY")).isEqualTo(this.dummy.metadata());
 	}
 
 	@Test(expected = TransportException.class)
@@ -87,12 +87,12 @@ public class PeerWithTransportTest {
 
 	@Test
 	public void testHasSystem() {
-		assertThat(this.pwt.hasSystem(), is(false));
+		assertThat(this.pwt.hasSystem()).isFalse();
 	}
 
 	@Test
 	public void testGetSystem() {
-		assertThat(this.pwt.getSystem(), nullValue());
+		assertThat(this.pwt.getSystem()).isNull();
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/InboundMessageEventTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/InboundMessageEventTest.java
@@ -29,7 +29,7 @@ import com.radixdlt.network.transport.TransportInfo;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -50,11 +50,11 @@ public class InboundMessageEventTest {
 		InboundMessageEvent event = new InboundMessageEvent(transportInfo, message, nanoTimeDiff);
 
 		String s = event.toString();
-		assertThat(s, containsString(InboundMessageEvent.class.getSimpleName()));
-		assertThat(s, containsString(transportInfo.toString()));
-		assertThat(s, containsString(message.toString()));
-		assertThat(s, containsString(String.valueOf(nanoTimeDiff)));
-		assertThat(s, containsString("priority=0"));
+		assertThat(s).contains(InboundMessageEvent.class.getSimpleName());
+		assertThat(s).contains(transportInfo.toString());
+		assertThat(s).contains(message.toString());
+		assertThat(s).contains(String.valueOf(nanoTimeDiff));
+		assertThat(s).contains("priority=0");
 	}
 
 	@Test
@@ -65,11 +65,11 @@ public class InboundMessageEventTest {
 		InboundMessageEvent event = new InboundMessageEvent(transportInfo, message, nanoTimeDiff);
 
 		String s = event.toString();
-		assertThat(s, containsString(InboundMessageEvent.class.getSimpleName()));
-		assertThat(s, containsString(transportInfo.toString()));
-		assertThat(s, containsString(message.toString()));
-		assertThat(s, containsString(String.valueOf(nanoTimeDiff)));
-		assertThat(s, containsString("priority=" + Integer.MIN_VALUE));
+		assertThat(s).contains(InboundMessageEvent.class.getSimpleName());
+		assertThat(s).contains(transportInfo.toString());
+		assertThat(s).contains(message.toString());
+		assertThat(s).contains(String.valueOf(nanoTimeDiff));
+		assertThat(s).contains("priority=" + Integer.MIN_VALUE);
 	}
 
 	@Test
@@ -80,11 +80,11 @@ public class InboundMessageEventTest {
 		InboundMessageEvent event = new InboundMessageEvent(transportInfo, message, nanoTimeDiff);
 
 		String s = event.toString();
-		assertThat(s, containsString(InboundMessageEvent.class.getSimpleName()));
-		assertThat(s, containsString(transportInfo.toString()));
-		assertThat(s, containsString(message.toString()));
-		assertThat(s, containsString(String.valueOf(nanoTimeDiff)));
-		assertThat(s, containsString("priority=" + Integer.MIN_VALUE));
+		assertThat(s).contains(InboundMessageEvent.class.getSimpleName());
+		assertThat(s).contains(transportInfo.toString());
+		assertThat(s).contains(message.toString());
+		assertThat(s).contains(String.valueOf(nanoTimeDiff));
+		assertThat(s).contains("priority=" + Integer.MIN_VALUE);
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/InboundMessageEventTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/InboundMessageEventTest.java
@@ -50,11 +50,12 @@ public class InboundMessageEventTest {
 		InboundMessageEvent event = new InboundMessageEvent(transportInfo, message, nanoTimeDiff);
 
 		String s = event.toString();
-		assertThat(s).contains(InboundMessageEvent.class.getSimpleName());
-		assertThat(s).contains(transportInfo.toString());
-		assertThat(s).contains(message.toString());
-		assertThat(s).contains(String.valueOf(nanoTimeDiff));
-		assertThat(s).contains("priority=0");
+		assertThat(s)
+			.contains(InboundMessageEvent.class.getSimpleName())
+			.contains(transportInfo.toString())
+			.contains(message.toString())
+			.contains(String.valueOf(nanoTimeDiff))
+			.contains("priority=0");
 	}
 
 	@Test
@@ -65,11 +66,12 @@ public class InboundMessageEventTest {
 		InboundMessageEvent event = new InboundMessageEvent(transportInfo, message, nanoTimeDiff);
 
 		String s = event.toString();
-		assertThat(s).contains(InboundMessageEvent.class.getSimpleName());
-		assertThat(s).contains(transportInfo.toString());
-		assertThat(s).contains(message.toString());
-		assertThat(s).contains(String.valueOf(nanoTimeDiff));
-		assertThat(s).contains("priority=" + Integer.MIN_VALUE);
+		assertThat(s)
+			.contains(InboundMessageEvent.class.getSimpleName())
+			.contains(transportInfo.toString())
+			.contains(message.toString())
+			.contains(String.valueOf(nanoTimeDiff))
+			.contains("priority=" + Integer.MIN_VALUE);
 	}
 
 	@Test
@@ -80,11 +82,12 @@ public class InboundMessageEventTest {
 		InboundMessageEvent event = new InboundMessageEvent(transportInfo, message, nanoTimeDiff);
 
 		String s = event.toString();
-		assertThat(s).contains(InboundMessageEvent.class.getSimpleName());
-		assertThat(s).contains(transportInfo.toString());
-		assertThat(s).contains(message.toString());
-		assertThat(s).contains(String.valueOf(nanoTimeDiff));
-		assertThat(s).contains("priority=" + Integer.MIN_VALUE);
+		assertThat(s)
+			.contains(InboundMessageEvent.class.getSimpleName())
+			.contains(transportInfo.toString())
+			.contains(message.toString())
+			.contains(String.valueOf(nanoTimeDiff))
+			.contains("priority=" + Integer.MIN_VALUE);
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/InboundMessageTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/InboundMessageTest.java
@@ -23,8 +23,7 @@ import org.junit.Test;
 import com.radixdlt.network.transport.StaticTransportMetadata;
 import com.radixdlt.network.transport.TransportInfo;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -48,17 +47,17 @@ public class InboundMessageTest {
 
 	@Test
 	public void testSource() {
-		assertThat(inboundMessage.source(), equalTo(transportInfo));
+		assertThat(inboundMessage.source()).isEqualTo(transportInfo);
 	}
 
 	@Test
 	public void testMessage() {
-		assertThat(inboundMessage.message(), equalTo(message));
+		assertThat(inboundMessage.message()).isEqualTo(message);
 	}
 
 	@Test
 	public void testToString() {
-		assertThat(inboundMessage.toString(), containsString("TEST")); // Transport name
-		assertThat(inboundMessage.toString(), containsString("000102030405060708090a")); // Message data in hex
+		assertThat(inboundMessage.toString()).contains("TEST"); // Transport name
+		assertThat(inboundMessage.toString()).contains("000102030405060708090a"); // Message data in hex
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/MessageDispatcherTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/MessageDispatcherTest.java
@@ -33,7 +33,6 @@ import com.radixdlt.network.transport.TransportInfo;
 import com.radixdlt.network.transport.TransportMetadata;
 import com.radixdlt.network.transport.TransportOutboundConnection;
 import com.radixdlt.serialization.Serialization;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
@@ -54,7 +53,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
@@ -181,7 +180,7 @@ public class MessageDispatcherTest extends RadixTest {
 
 		SendResult sendResult = messageDispatcher.send(transportManager, messageEvent).get();
 
-		assertThat(sendResult.getThrowable().getMessage(), Matchers.equalTo("TTL for TestMessage message to " + peer1 + " has expired"));
+		assertThat(sendResult.getThrowable().getMessage()).isEqualTo("TTL for TestMessage message to " + peer1 + " has expired");
 		verify(counters, times(1)).increment(CounterType.MESSAGES_OUTBOUND_ABORTED);
 	}
 
@@ -209,7 +208,7 @@ public class MessageDispatcherTest extends RadixTest {
 		messageDispatcher.receive(messageListenerList, messageEvent);
 
 		assertTrue(receivedFlag.tryAcquire(10, TimeUnit.SECONDS));
-		assertThat(messages.get(0), Matchers.equalTo(testMessage));
+		assertThat(messages.get(0)).isEqualTo(testMessage);
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/MessageListenerListTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/MessageListenerListTest.java
@@ -27,9 +27,8 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 // Unit tests for MessageListenerList
 public class MessageListenerListTest {
@@ -51,20 +50,20 @@ public class MessageListenerListTest {
 
 		listenerList.addMessageListener(listener);
 		// Should not have been called yet
-		assertThat(called, equalTo(0));
+		assertThat(called).isEqualTo(0);
 
 		listenerList.messageReceived(null, null);
 		// Should have been called because of messageReceived()
-		assertThat(called, equalTo(1));
+		assertThat(called).isEqualTo(1);
 
 		listenerList.messageReceived(null, null);
 		// Should have been called again because of messageReceived
-		assertThat(called, equalTo(2));
+		assertThat(called).isEqualTo(2);
 
 		listenerList.removeMessageListener(listener);
 		listenerList.messageReceived(null, null);
 		// Should not have been called -> removed
-		assertThat(called, equalTo(2));
+		assertThat(called).isEqualTo(2);
 	}
 
 	@Test
@@ -73,16 +72,16 @@ public class MessageListenerListTest {
 
 		listenerList.addMessageListener(listener);
 		// Should not have been called yet
-		assertThat(called, equalTo(0));
+		assertThat(called).isEqualTo(0);
 
 		listenerList.messageReceived(null, null);
 		// Should have been called because of messageReceived()
-		assertThat(called, equalTo(1));
+		assertThat(called).isEqualTo(1);
 
 		listenerList.removeAllMessageListeners();
 		listenerList.messageReceived(null, null);
 		// Should not have been called -> removed
-		assertThat(called, equalTo(1));
+		assertThat(called).isEqualTo(1);
 	}
 
 	private final MessageListener<TestMessage> testListener = new MessageListener<>() {
@@ -96,13 +95,13 @@ public class MessageListenerListTest {
 	// Test that we can remove callbacks in a callback without deadlocking
 	@Test
 	public void testRemoveOwnCallback() {
-		assertThat(called, equalTo(0)); // precondition
+		assertThat(called).isEqualTo(0); // precondition
 		listenerList.addMessageListener(testListener);
-		assertThat(called, equalTo(0)); // nothing happened
+		assertThat(called).isEqualTo(0); // nothing happened
 		listenerList.messageReceived(null, null);
-		assertThat(called, equalTo(1)); // called and removed itself
+		assertThat(called).isEqualTo(1); // called and removed itself
 		listenerList.messageReceived(null, null);
-		assertThat(called, equalTo(1)); // was removed, so didn't happen again
+		assertThat(called).isEqualTo(1); // was removed, so didn't happen again
 	}
 
 	// Test that we can remove a callback for another thread in this thread w/o deadlock
@@ -127,9 +126,9 @@ public class MessageListenerListTest {
 			if (message != null) {
 				cond.awaitUninterruptibly();
 				lock.unlock();
-				assertThat(called, equalTo(0));
+				assertThat(called).isEqualTo(0);
 				listenerList.removeMessageListener(listener1);
-				assertThat(called, equalTo(1));
+				assertThat(called).isEqualTo(1);
 			}
 		};
 		listenerList.addMessageListener(listener1);

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/MessageListenerListTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/MessageListenerListTest.java
@@ -50,7 +50,7 @@ public class MessageListenerListTest {
 
 		listenerList.addMessageListener(listener);
 		// Should not have been called yet
-		assertThat(called).isEqualTo(0);
+		assertThat(called).isZero();
 
 		listenerList.messageReceived(null, null);
 		// Should have been called because of messageReceived()
@@ -72,7 +72,7 @@ public class MessageListenerListTest {
 
 		listenerList.addMessageListener(listener);
 		// Should not have been called yet
-		assertThat(called).isEqualTo(0);
+		assertThat(called).isZero();
 
 		listenerList.messageReceived(null, null);
 		// Should have been called because of messageReceived()
@@ -95,9 +95,9 @@ public class MessageListenerListTest {
 	// Test that we can remove callbacks in a callback without deadlocking
 	@Test
 	public void testRemoveOwnCallback() {
-		assertThat(called).isEqualTo(0); // precondition
+		assertThat(called).isZero(); // precondition
 		listenerList.addMessageListener(testListener);
-		assertThat(called).isEqualTo(0); // nothing happened
+		assertThat(called).isZero(); // nothing happened
 		listenerList.messageReceived(null, null);
 		assertThat(called).isEqualTo(1); // called and removed itself
 		listenerList.messageReceived(null, null);
@@ -126,7 +126,7 @@ public class MessageListenerListTest {
 			if (message != null) {
 				cond.awaitUninterruptibly();
 				lock.unlock();
-				assertThat(called).isEqualTo(0);
+				assertThat(called).isZero();
 				listenerList.removeMessageListener(listener1);
 				assertThat(called).isEqualTo(1);
 			}

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/OutboundMessageEventTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/OutboundMessageEventTest.java
@@ -49,11 +49,12 @@ public class OutboundMessageEventTest {
 		OutboundMessageEvent event = new OutboundMessageEvent(peer, message, nanoTimeDiff);
 
 		String s = event.toString();
-		assertThat(s).contains(OutboundMessageEvent.class.getSimpleName());
-		assertThat(s).contains(peer.toString());
-		assertThat(s).contains(message.toString());
-		assertThat(s).contains(String.valueOf(nanoTimeDiff));
-		assertThat(s).contains("priority=0");
+		assertThat(s)
+			.contains(OutboundMessageEvent.class.getSimpleName())
+			.contains(peer.toString())
+			.contains(message.toString())
+			.contains(String.valueOf(nanoTimeDiff))
+			.contains("priority=0");
 	}
 
 	@Test
@@ -64,11 +65,12 @@ public class OutboundMessageEventTest {
 		OutboundMessageEvent event = new OutboundMessageEvent(peer, message, nanoTimeDiff);
 
 		String s = event.toString();
-		assertThat(s).contains(OutboundMessageEvent.class.getSimpleName());
-		assertThat(s).contains(peer.toString());
-		assertThat(s).contains(message.toString());
-		assertThat(s).contains(String.valueOf(nanoTimeDiff));
-		assertThat(s).contains("priority=" + Integer.MIN_VALUE);
+		assertThat(s)
+			.contains(OutboundMessageEvent.class.getSimpleName())
+			.contains(peer.toString())
+			.contains(message.toString())
+			.contains(String.valueOf(nanoTimeDiff))
+			.contains("priority=" + Integer.MIN_VALUE);
 	}
 
 	@Test
@@ -79,11 +81,12 @@ public class OutboundMessageEventTest {
 		OutboundMessageEvent event = new OutboundMessageEvent(peer, message, nanoTimeDiff);
 
 		String s = event.toString();
-		assertThat(s).contains(OutboundMessageEvent.class.getSimpleName());
-		assertThat(s).contains(peer.toString());
-		assertThat(s).contains(message.toString());
-		assertThat(s).contains(String.valueOf(nanoTimeDiff));
-		assertThat(s).contains("priority=" + Integer.MIN_VALUE);
+		assertThat(s)
+			.contains(OutboundMessageEvent.class.getSimpleName())
+			.contains(peer.toString())
+			.contains(message.toString())
+			.contains(String.valueOf(nanoTimeDiff))
+			.contains("priority=" + Integer.MIN_VALUE);
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/OutboundMessageEventTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/messaging/OutboundMessageEventTest.java
@@ -28,7 +28,7 @@ import com.google.common.collect.Lists;
 import com.radixdlt.network.addressbook.Peer;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -49,11 +49,11 @@ public class OutboundMessageEventTest {
 		OutboundMessageEvent event = new OutboundMessageEvent(peer, message, nanoTimeDiff);
 
 		String s = event.toString();
-		assertThat(s, containsString(OutboundMessageEvent.class.getSimpleName()));
-		assertThat(s, containsString(peer.toString()));
-		assertThat(s, containsString(message.toString()));
-		assertThat(s, containsString(String.valueOf(nanoTimeDiff)));
-		assertThat(s, containsString("priority=0"));
+		assertThat(s).contains(OutboundMessageEvent.class.getSimpleName());
+		assertThat(s).contains(peer.toString());
+		assertThat(s).contains(message.toString());
+		assertThat(s).contains(String.valueOf(nanoTimeDiff));
+		assertThat(s).contains("priority=0");
 	}
 
 	@Test
@@ -64,11 +64,11 @@ public class OutboundMessageEventTest {
 		OutboundMessageEvent event = new OutboundMessageEvent(peer, message, nanoTimeDiff);
 
 		String s = event.toString();
-		assertThat(s, containsString(OutboundMessageEvent.class.getSimpleName()));
-		assertThat(s, containsString(peer.toString()));
-		assertThat(s, containsString(message.toString()));
-		assertThat(s, containsString(String.valueOf(nanoTimeDiff)));
-		assertThat(s, containsString("priority=" + Integer.MIN_VALUE));
+		assertThat(s).contains(OutboundMessageEvent.class.getSimpleName());
+		assertThat(s).contains(peer.toString());
+		assertThat(s).contains(message.toString());
+		assertThat(s).contains(String.valueOf(nanoTimeDiff));
+		assertThat(s).contains("priority=" + Integer.MIN_VALUE);
 	}
 
 	@Test
@@ -79,11 +79,11 @@ public class OutboundMessageEventTest {
 		OutboundMessageEvent event = new OutboundMessageEvent(peer, message, nanoTimeDiff);
 
 		String s = event.toString();
-		assertThat(s, containsString(OutboundMessageEvent.class.getSimpleName()));
-		assertThat(s, containsString(peer.toString()));
-		assertThat(s, containsString(message.toString()));
-		assertThat(s, containsString(String.valueOf(nanoTimeDiff)));
-		assertThat(s, containsString("priority=" + Integer.MIN_VALUE));
+		assertThat(s).contains(OutboundMessageEvent.class.getSimpleName());
+		assertThat(s).contains(peer.toString());
+		assertThat(s).contains(message.toString());
+		assertThat(s).contains(String.valueOf(nanoTimeDiff));
+		assertThat(s).contains("priority=" + Integer.MIN_VALUE);
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/DynamicTransportMetadataTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/DynamicTransportMetadataTest.java
@@ -25,9 +25,7 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class DynamicTransportMetadataTest {
@@ -43,8 +41,8 @@ public class DynamicTransportMetadataTest {
 		metadata.put("a", () -> "b");
 		DynamicTransportMetadata dtm = DynamicTransportMetadata.from(metadata);
 
-		assertThat(dtm.get("a"), equalTo("b"));
-		assertThat(dtm.get("b"), nullValue());
+		assertThat(dtm.get("a")).isEqualTo("b");
+		assertThat(dtm.get("b")).isNull();
 	}
 
 	@Test
@@ -53,32 +51,32 @@ public class DynamicTransportMetadataTest {
 			ImmutableMap.of("a", () -> "b")
 		);
 
-		assertThat(dtm.get("a"), equalTo("b"));
-		assertThat(dtm.get("b"), nullValue());
+		assertThat(dtm.get("a")).isEqualTo("b");
+		assertThat(dtm.get("b")).isNull();
 	}
 
 	@Test
 	public void testOfTwoArgs() {
 		DynamicTransportMetadata dtm = DynamicTransportMetadata.of("a", () -> "b");
 
-		assertThat(dtm.get("a"), equalTo("b"));
-		assertThat(dtm.get("b"), nullValue());
+		assertThat(dtm.get("a")).isEqualTo("b");
+		assertThat(dtm.get("b")).isNull();
 	}
 
 	@Test
 	public void testOfFourArgs() {
 		DynamicTransportMetadata dtm = DynamicTransportMetadata.of("a", () -> "b", "c", () -> "d");
 
-		assertThat(dtm.get("a"), equalTo("b"));
-		assertThat(dtm.get("c"), equalTo("d"));
-		assertThat(dtm.get("e"), nullValue());
+		assertThat(dtm.get("a")).isEqualTo("b");
+		assertThat(dtm.get("c")).isEqualTo("d");
+		assertThat(dtm.get("e")).isNull();
 	}
 
 	@Test
 	public void testToString() {
 		DynamicTransportMetadata dtm = DynamicTransportMetadata.of("a", () -> "b", "c", () -> "d");
 
-		assertThat(dtm.toString(), containsString("a=b"));
-		assertThat(dtm.toString(), containsString("c=d"));
+		assertThat(dtm.toString()).contains("a=b");
+		assertThat(dtm.toString()).contains("c=d");
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/FirstMatchTransportManagerTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/FirstMatchTransportManagerTest.java
@@ -31,9 +31,9 @@ import com.google.common.collect.ImmutableSet;
 import com.radixdlt.network.addressbook.Peer;
 import com.radixdlt.network.transport.udp.UDPConstants;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-import static org.hamcrest.CoreMatchers.*;
 
 public class FirstMatchTransportManagerTest {
 
@@ -110,9 +110,9 @@ public class FirstMatchTransportManagerTest {
 
 	@Test
 	public void testClose() throws IOException {
-		assertThat(closed.get(), equalTo(0)); // Precondition
+		assertThat(closed.get()).isEqualTo(0); // Precondition
 		transportManager.close(); // Close everything
-		assertThat(closed.get(), equalTo(1));
+		assertThat(closed.get()).isEqualTo(1);
 	}
 
 	@Test
@@ -120,15 +120,15 @@ public class FirstMatchTransportManagerTest {
 		Set<String> transports = transportManager.transports().stream()
 			.map(Transport::name)
 			.collect(Collectors.toSet());
-		assertThat(transports, hasItem("DUMMY"));
-		assertThat(transports, hasItem(UDPConstants.NAME));
+		assertThat(transports).contains("DUMMY");
+		assertThat(transports).contains(UDPConstants.NAME);
 	}
 
 
 	@Test
 	public void testToString() {
 		String s = transportManager.toString();
-		assertThat(s, containsString("DUMMY"));
-		assertThat(s, containsString(UDPConstants.NAME));
+		assertThat(s).contains("DUMMY");
+		assertThat(s).contains(UDPConstants.NAME);
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/FirstMatchTransportManagerTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/FirstMatchTransportManagerTest.java
@@ -110,7 +110,7 @@ public class FirstMatchTransportManagerTest {
 
 	@Test
 	public void testClose() throws IOException {
-		assertThat(closed.get()).isEqualTo(0); // Precondition
+		assertThat(closed.get()).isZero(); // Precondition
 		transportManager.close(); // Close everything
 		assertThat(closed.get()).isEqualTo(1);
 	}
@@ -120,15 +120,17 @@ public class FirstMatchTransportManagerTest {
 		Set<String> transports = transportManager.transports().stream()
 			.map(Transport::name)
 			.collect(Collectors.toSet());
-		assertThat(transports).contains("DUMMY");
-		assertThat(transports).contains(UDPConstants.NAME);
+		assertThat(transports)
+			.contains("DUMMY")
+			.contains(UDPConstants.NAME);
 	}
 
 
 	@Test
 	public void testToString() {
 		String s = transportManager.toString();
-		assertThat(s).contains("DUMMY");
-		assertThat(s).contains(UDPConstants.NAME);
+		assertThat(s)
+			.contains("DUMMY")
+			.contains(UDPConstants.NAME);
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/SendResultTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/SendResultTest.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
 
 public class SendResultTest {
 
@@ -30,7 +30,7 @@ public class SendResultTest {
 	public void testComplete() {
 		SendResult complete = SendResult.complete();
 
-		assertThat(complete.toString(), containsString("Complete"));
+		assertThat(complete.toString()).contains("Complete");
 		assertTrue(complete.isComplete());
 	}
 
@@ -38,7 +38,7 @@ public class SendResultTest {
 	public void testFailure() {
 		SendResult complete = SendResult.failure(new IOException());
 
-		assertThat(complete.toString(), containsString(IOException.class.getName()));
+		assertThat(complete.toString()).contains(IOException.class.getName());
 		assertFalse(complete.isComplete());
 	}
 
@@ -46,7 +46,7 @@ public class SendResultTest {
 	public void testGetException() {
 		SendResult complete = SendResult.failure(new IOException());
 
-		assertThat(complete.getThrowable(), notNullValue());
-		assertThat(complete.getThrowable().getClass().getName(), equalTo(IOException.class.getName()));
+		assertThat(complete.getThrowable()).isNotNull();
+		assertThat(complete.getThrowable().getClass().getName()).isEqualTo(IOException.class.getName());
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/StaticTransportMetadataTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/StaticTransportMetadataTest.java
@@ -23,9 +23,7 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class StaticTransportMetadataTest {
@@ -39,7 +37,7 @@ public class StaticTransportMetadataTest {
 	public void testEmpty() {
 		StaticTransportMetadata stm = StaticTransportMetadata.empty();
 
-		assertThat(stm.toString(), containsString("{}")); // The empty map
+		assertThat(stm.toString()).contains("{}"); // The empty map
 	}
 
 	@Test
@@ -48,8 +46,8 @@ public class StaticTransportMetadataTest {
 		metadata.put("a", "b");
 		StaticTransportMetadata stm = StaticTransportMetadata.from(metadata);
 
-		assertThat(stm.get("a"), equalTo("b"));
-		assertThat(stm.get("b"), nullValue());
+		assertThat(stm.get("a")).isEqualTo("b");
+		assertThat(stm.get("b")).isNull();
 	}
 
 	@Test
@@ -58,32 +56,32 @@ public class StaticTransportMetadataTest {
 			ImmutableMap.of("a", "b")
 		);
 
-		assertThat(stm.get("a"), equalTo("b"));
-		assertThat(stm.get("b"), nullValue());
+		assertThat(stm.get("a")).isEqualTo("b");
+		assertThat(stm.get("b")).isNull();
 	}
 
 	@Test
 	public void testOfTwoArgs() {
 		StaticTransportMetadata stm = StaticTransportMetadata.of("a", "b");
 
-		assertThat(stm.get("a"), equalTo("b"));
-		assertThat(stm.get("b"), nullValue());
+		assertThat(stm.get("a")).isEqualTo("b");
+		assertThat(stm.get("b")).isNull();
 	}
 
 	@Test
 	public void testOfFourArgs() {
 		StaticTransportMetadata stm = StaticTransportMetadata.of("a", "b", "c", "d");
 
-		assertThat(stm.get("a"), equalTo("b"));
-		assertThat(stm.get("c"), equalTo("d"));
-		assertThat(stm.get("e"), nullValue());
+		assertThat(stm.get("a")).isEqualTo("b");
+		assertThat(stm.get("c")).isEqualTo("d");
+		assertThat(stm.get("e")).isNull();
 	}
 
 	@Test
 	public void testToString() {
 		StaticTransportMetadata stm = StaticTransportMetadata.of("a", "b", "c", "d");
 
-		assertThat(stm.toString(), containsString("a=b"));
-		assertThat(stm.toString(), containsString("c=d"));
+		assertThat(stm.toString()).contains("a=b");
+		assertThat(stm.toString()).contains("c=d");
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/TransportInfoTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/TransportInfoTest.java
@@ -19,9 +19,7 @@ package com.radixdlt.network.transport;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class TransportInfoTest {
@@ -36,8 +34,8 @@ public class TransportInfoTest {
 		StaticTransportMetadata stm = StaticTransportMetadata.of("a", "b");
 		TransportInfo info = TransportInfo.of("TEST", stm);
 
-		assertThat(info.name(), equalTo("TEST"));
-		assertThat(info.metadata(), equalTo(stm));
+		assertThat(info.name()).isEqualTo("TEST");
+		assertThat(info.metadata()).isEqualTo(stm);
 	}
 
 	@Test
@@ -45,7 +43,7 @@ public class TransportInfoTest {
 		StaticTransportMetadata stm = StaticTransportMetadata.of("a", "b");
 		TransportInfo info = TransportInfo.of("TEST", stm);
 
-		assertThat(info.toString(), containsString("TEST"));
-		assertThat(info.toString(), containsString("a=b"));
+		assertThat(info.toString()).contains("TEST");
+		assertThat(info.toString()).contains("a=b");
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/tcp/NettyTCPTransportImplTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/tcp/NettyTCPTransportImplTest.java
@@ -24,9 +24,9 @@ import org.junit.Test;
 import com.radixdlt.network.transport.StaticTransportMetadata;
 import com.radixdlt.network.transport.TransportMetadata;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-import static org.hamcrest.CoreMatchers.*;
 
 public class NettyTCPTransportImplTest {
 
@@ -158,9 +158,9 @@ public class NettyTCPTransportImplTest {
 
 		try (NettyTCPTransportImpl testInstance = new NettyTCPTransportImpl(config, localMetadata, outboundFactory, controlFactory)) {
 			String s = testInstance.toString();
-			assertThat(s, containsString(NettyTCPTransportImpl.class.getSimpleName()));
-			assertThat(s, containsString(NettyTCPTransportImpl.DEFAULT_HOST));
-			assertThat(s, containsString(String.valueOf(NettyTCPTransportImpl.DEFAULT_PORT)));
+			assertThat(s).contains(NettyTCPTransportImpl.class.getSimpleName());
+			assertThat(s).contains(NettyTCPTransportImpl.DEFAULT_HOST);
+			assertThat(s).contains(String.valueOf(NettyTCPTransportImpl.DEFAULT_PORT));
 		}
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/tcp/TCPTransportOutboundConnectionImplTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/tcp/TCPTransportOutboundConnectionImplTest.java
@@ -27,8 +27,8 @@ import com.radixdlt.network.transport.SendResult;
 import com.radixdlt.network.transport.StaticTransportMetadata;
 import com.radixdlt.network.transport.TransportMetadata;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -176,8 +176,8 @@ public class TCPTransportOutboundConnectionImplTest {
 		TCPTransportOutboundConnectionImpl oci = new TCPTransportOutboundConnectionImpl(channel, metadata);
 		String s = oci.toString();
 
-		assertThat(s, containsString(TCPConstants.NAME));
-		assertThat(s, containsString(metadata.get(TCPConstants.METADATA_HOST)));
-		assertThat(s, containsString(metadata.get(TCPConstants.METADATA_PORT)));
+		assertThat(s).contains(TCPConstants.NAME);
+		assertThat(s).contains(metadata.get(TCPConstants.METADATA_HOST));
+		assertThat(s).contains(metadata.get(TCPConstants.METADATA_PORT));
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/tcp/TCPTransportOutboundConnectionImplTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/tcp/TCPTransportOutboundConnectionImplTest.java
@@ -176,8 +176,9 @@ public class TCPTransportOutboundConnectionImplTest {
 		TCPTransportOutboundConnectionImpl oci = new TCPTransportOutboundConnectionImpl(channel, metadata);
 		String s = oci.toString();
 
-		assertThat(s).contains(TCPConstants.NAME);
-		assertThat(s).contains(metadata.get(TCPConstants.METADATA_HOST));
-		assertThat(s).contains(metadata.get(TCPConstants.METADATA_PORT));
+		assertThat(s)
+			.contains(TCPConstants.NAME)
+			.contains(metadata.get(TCPConstants.METADATA_HOST))
+			.contains(metadata.get(TCPConstants.METADATA_PORT));
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/udp/NettyUDPTransportImplTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/udp/NettyUDPTransportImplTest.java
@@ -24,9 +24,9 @@ import org.junit.Test;
 import com.radixdlt.network.transport.StaticTransportMetadata;
 import com.radixdlt.network.transport.TransportMetadata;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-import static org.hamcrest.CoreMatchers.*;
 
 public class NettyUDPTransportImplTest {
 
@@ -161,9 +161,9 @@ public class NettyUDPTransportImplTest {
 
 		try (NettyUDPTransportImpl testInstance = new NettyUDPTransportImpl(config, localMetadata, controlFactory, connectionFactory, natHandler)) {
 			String s = testInstance.toString();
-			assertThat(s, containsString(NettyUDPTransportImpl.class.getSimpleName()));
-			assertThat(s, containsString(NettyUDPTransportImpl.DEFAULT_HOST));
-			assertThat(s, containsString(String.valueOf(NettyUDPTransportImpl.DEFAULT_PORT)));
+			assertThat(s).contains(NettyUDPTransportImpl.class.getSimpleName());
+			assertThat(s).contains(NettyUDPTransportImpl.DEFAULT_HOST);
+			assertThat(s).contains(String.valueOf(NettyUDPTransportImpl.DEFAULT_PORT));
 		}
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/udp/UDPTransportOutboundConnectionTest2.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/udp/UDPTransportOutboundConnectionTest2.java
@@ -70,8 +70,9 @@ public class UDPTransportOutboundConnectionTest2 {
 		UDPTransportOutboundConnection oci = new UDPTransportOutboundConnection(channel, metadata, natHandler);
 		String s = oci.toString();
 
-		assertThat(s).contains(UDPConstants.NAME);
-		assertThat(s).contains(metadata.get(UDPConstants.METADATA_HOST));
-		assertThat(s).contains(metadata.get(UDPConstants.METADATA_PORT));
+		assertThat(s)
+			.contains(UDPConstants.NAME)
+			.contains(metadata.get(UDPConstants.METADATA_HOST))
+			.contains(metadata.get(UDPConstants.METADATA_PORT));
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/udp/UDPTransportOutboundConnectionTest2.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/transport/udp/UDPTransportOutboundConnectionTest2.java
@@ -30,8 +30,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class UDPTransportOutboundConnectionTest2 {
@@ -72,8 +70,8 @@ public class UDPTransportOutboundConnectionTest2 {
 		UDPTransportOutboundConnection oci = new UDPTransportOutboundConnection(channel, metadata, natHandler);
 		String s = oci.toString();
 
-		assertThat(s, containsString(UDPConstants.NAME));
-		assertThat(s, containsString(metadata.get(UDPConstants.METADATA_HOST)));
-		assertThat(s, containsString(metadata.get(UDPConstants.METADATA_PORT)));
+		assertThat(s).contains(UDPConstants.NAME);
+		assertThat(s).contains(metadata.get(UDPConstants.METADATA_HOST));
+		assertThat(s).contains(metadata.get(UDPConstants.METADATA_PORT));
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/properties/PersistedPropertiesTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/properties/PersistedPropertiesTest.java
@@ -137,10 +137,11 @@ public class PersistedPropertiesTest {
 	public void testToString() {
 		populateData();
 		String result = this.properties.toString();
-		assertThat(result).contains("int.exist");
-		assertThat(result).contains("long.exist");
-		assertThat(result).contains("bool.true");
-		assertThat(result).contains("bool.true1");
+		assertThat(result)
+			.contains("int.exist")
+			.contains("long.exist")
+			.contains("bool.true")
+			.contains("bool.true1");
 	}
 
 	private void populateData() {

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/properties/PersistedPropertiesTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/properties/PersistedPropertiesTest.java
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -54,9 +54,9 @@ public class PersistedPropertiesTest {
 		assertFalse(Files.exists(Paths.get(testProperties)));
 
 		this.properties.load(testProperties); // Should load from resources
-		assertThat(this.properties.get("a"), is("a"));
-		assertThat(this.properties.get("b"), is("b"));
-		assertThat(this.properties.get("c"), nullValue());
+		assertThat(this.properties.get("a")).isEqualTo("a");
+		assertThat(this.properties.get("b")).isEqualTo("b");
+		assertThat(this.properties.get("c")).isNull();
 	}
 
 	@Test
@@ -72,9 +72,9 @@ public class PersistedPropertiesTest {
 
 		PersistedProperties newCut = new PersistedProperties();
 		newCut.load(testProperties); // Should load from file
-		assertThat(this.properties.get("a"), is("a"));
-		assertThat(this.properties.get("b"), is("b"));
-		assertThat(this.properties.get("c"), is("c"));
+		assertThat(this.properties.get("a")).isEqualTo("a");
+		assertThat(this.properties.get("b")).isEqualTo("b");
+		assertThat(this.properties.get("c")).isEqualTo("c");
 	}
 
 	@Test
@@ -137,10 +137,10 @@ public class PersistedPropertiesTest {
 	public void testToString() {
 		populateData();
 		String result = this.properties.toString();
-		assertThat(result, containsString("int.exist"));
-		assertThat(result, containsString("long.exist"));
-		assertThat(result, containsString("bool.true"));
-		assertThat(result, containsString("bool.true1"));
+		assertThat(result).contains("int.exist");
+		assertThat(result).contains("long.exist");
+		assertThat(result).contains("bool.true");
+		assertThat(result).contains("bool.true1");
 	}
 
 	private void populateData() {

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/properties/RuntimePropertiesTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/properties/RuntimePropertiesTest.java
@@ -98,7 +98,8 @@ public class RuntimePropertiesTest {
 	@Test
 	public void testToString() {
 		String result = this.properties.toString();
-		assertThat(result).contains("[a, b]");
-		assertThat(result).contains("args=[]");
+		assertThat(result)
+			.contains("[a, b]")
+			.contains("args=[]");
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/properties/RuntimePropertiesTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/properties/RuntimePropertiesTest.java
@@ -27,8 +27,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.*;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -87,18 +87,18 @@ public class RuntimePropertiesTest {
 
 	@Test
 	public void testGet() {
-		assertThat(this.properties.get("a"), is("a"));
-		assertThat(this.properties.get("b"), is("b"));
-		assertThat(this.properties.get("c"), is(TEST_PROPERTIES));
-		assertThat(this.properties.get("ta"), is(TEST_OPTION));
-		assertThat(this.properties.get("tn"), is("1"));
-		assertThat(this.properties.get("notexist"), nullValue());
+		assertThat(this.properties.get("a")).isEqualTo("a");
+		assertThat(this.properties.get("b")).isEqualTo("b");
+		assertThat(this.properties.get("c")).isEqualTo(TEST_PROPERTIES);
+		assertThat(this.properties.get("ta")).isEqualTo(TEST_OPTION);
+		assertThat(this.properties.get("tn")).isEqualTo("1");
+		assertThat(this.properties.get("notexist")).isNull();
 	}
 
 	@Test
 	public void testToString() {
 		String result = this.properties.toString();
-		assertThat(result, containsString("[a, b]"));
-		assertThat(result, containsString("args=[]"));
+		assertThat(result).contains("[a, b]");
+		assertThat(result).contains("args=[]");
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/Executor.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/Executor.java
@@ -91,7 +91,7 @@ public final class Executor {
 			.collect(
 				toMap(
 					SanityTestScenarioRunner::testScenarioIdentifier,
-					s -> s::executeTest
+					s -> scenario -> s.executeTest(scenario)
 				)
 			);
 	}

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/hashing/HashingTestScenarioRunner.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/hashing/HashingTestScenarioRunner.java
@@ -23,6 +23,7 @@ import com.radixdlt.utils.Bytes;
 import static org.junit.Assert.assertEquals;
 
 public final class HashingTestScenarioRunner extends SanityTestScenarioRunner<HashingTestVector> {
+	@Override
 	public String testScenarioIdentifier() {
 		return "hashing";
 	}
@@ -32,6 +33,7 @@ public final class HashingTestScenarioRunner extends SanityTestScenarioRunner<Ha
 		return HashingTestVector.class;
 	}
 
+	@Override
 	public void doRunTestVector(HashingTestVector testVector) throws AssertionError {
 		var hashHex = Bytes.toHexString(sha256Hash(testVector.input.bytesToHash()));
 

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/jsondeserialization/JsonDeserializationTestScenarioRunner.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/jsondeserialization/JsonDeserializationTestScenarioRunner.java
@@ -29,9 +29,6 @@ import com.radixdlt.sanitytestsuite.utility.ArgumentsExtractor;
 import com.radixdlt.serialization.DeserializeException;
 import com.radixdlt.serialization.Serialization;
 import com.radixdlt.utils.Pair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -41,11 +38,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public final class JsonDeserializationTestScenarioRunner extends SanityTestScenarioRunner<JsonDeserializationTestVector> {
-	private static final Logger LOG = LogManager.getLogger();
-
 	private final Serialization serialization = DefaultSerialization.getInstance();
 	private final ObjectMapper mapper = new ObjectMapper();
 
+	@Override
 	public String testScenarioIdentifier() {
 		return "json_deserialization_radix_models";
 	}
@@ -124,6 +120,7 @@ public final class JsonDeserializationTestScenarioRunner extends SanityTestScena
 		"radix.particles.message", JsonDeserializationTestScenarioRunner::assertEqualModelMessageParticle
 	);
 
+	@Override
 	public void doRunTestVector(JsonDeserializationTestVector testVector) throws AssertionError {
 
 		var assertEqualModel = ofNullable(

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/jsonserialization/JsonSerializationTestScenarioRunner.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/jsonserialization/JsonSerializationTestScenarioRunner.java
@@ -26,9 +26,6 @@ import com.radixdlt.sanitytestsuite.utility.ArgumentsExtractor;
 import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.serialization.Serialization;
 import com.radixdlt.utils.JSONFormatter;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.function.Function;
@@ -38,10 +35,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public final class JsonSerializationTestScenarioRunner extends SanityTestScenarioRunner<JsonSerializationTestVector> {
-	private static final Logger LOG = LogManager.getLogger();
-
 	private final Serialization serialization = DefaultSerialization.getInstance();
 
+	@Override
 	public String testScenarioIdentifier() {
 		return "json_serialization_radix_models";
 	}
@@ -88,6 +84,7 @@ public final class JsonSerializationTestScenarioRunner extends SanityTestScenari
 		"radix.particles.message", JsonSerializationTestScenarioRunner::makeMessageParticle
 	);
 
+	@Override
 	public void doRunTestVector(JsonSerializationTestVector testVector) throws AssertionError {
 		var produced = ofNullable(constructorMap.get(testVector.input.typeSerialization))
 			.map(constructor -> constructor.apply(testVector.input.arguments))

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/keygen/KeyGenTestScenarioRunner.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/keygen/KeyGenTestScenarioRunner.java
@@ -25,6 +25,7 @@ import static com.radixdlt.utils.Bytes.fromHexString;
 import static junit.framework.TestCase.assertEquals;
 
 public final class KeyGenTestScenarioRunner extends SanityTestScenarioRunner<KeyGenTestVector> {
+	@Override
 	public String testScenarioIdentifier() {
 		return "secp256k1";
 	}
@@ -34,6 +35,7 @@ public final class KeyGenTestScenarioRunner extends SanityTestScenarioRunner<Key
 		return KeyGenTestVector.class;
 	}
 
+	@Override
 	public void doRunTestVector(KeyGenTestVector testVector) throws AssertionError {
 		try {
 			var	publicKey =

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/keysign/KeySignTestScenarioRunner.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/keysign/KeySignTestScenarioRunner.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 
 public final class KeySignTestScenarioRunner extends SanityTestScenarioRunner<KeySignTestVector> {
 
+	@Override
 	public String testScenarioIdentifier() {
 		return "ecdsa_signing";
 	}
@@ -37,6 +38,7 @@ public final class KeySignTestScenarioRunner extends SanityTestScenarioRunner<Ke
 		return KeySignTestVector.class;
 	}
 
+	@Override
 	public void doRunTestVector(KeySignTestVector testVector) throws AssertionError {
 		ECKeyPair keyPair = null;
 		try {

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/keyverify/KeyVerifyTestScenarioRunner.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/keyverify/KeyVerifyTestScenarioRunner.java
@@ -25,6 +25,7 @@ import static com.radixdlt.utils.Bytes.fromHexString;
 import static org.junit.Assert.assertEquals;
 
 public final class KeyVerifyTestScenarioRunner extends SanityTestScenarioRunner<KeyVerifyTestVector> {
+	@Override
 	public String testScenarioIdentifier() {
 		return "ecdsa_verification";
 	}
@@ -34,6 +35,7 @@ public final class KeyVerifyTestScenarioRunner extends SanityTestScenarioRunner<
 		return KeyVerifyTestVector.class;
 	}
 
+	@Override
 	public void doRunTestVector(KeyVerifyTestVector testVector) throws AssertionError {
 
 		ECPublicKey publicKey = null;

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/radixhashing/RadixHashingTestScenarioRunner.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/radixhashing/RadixHashingTestScenarioRunner.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 
 public final class RadixHashingTestScenarioRunner extends SanityTestScenarioRunner<RadixHashingTestVector> {
 
+	@Override
 	public String testScenarioIdentifier() {
 		return "radix_hashing";
 	}
@@ -34,6 +35,7 @@ public final class RadixHashingTestScenarioRunner extends SanityTestScenarioRunn
 		return RadixHashingTestVector.class;
 	}
 
+	@Override
 	public void doRunTestVector(RadixHashingTestVector testVector) throws AssertionError {
 		var hashHex = Bytes.toHexString(HashUtils.sha256(testVector.input.bytesToHash()).asBytes());
 

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/network/messages/GetPeersMessageTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/network/messages/GetPeersMessageTest.java
@@ -24,8 +24,7 @@ import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.radix.serialization.SerializeMessageObject;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GetPeersMessageTest extends SerializeMessageObject<GetPeersMessage> {
 
@@ -37,7 +36,7 @@ public class GetPeersMessageTest extends SerializeMessageObject<GetPeersMessage>
 	public void sensibleToString() {
 		String s = new GetPeersMessage().toString();
 
-		assertThat(s, containsString(GetPeersMessage.class.getSimpleName()));
+		assertThat(s).contains(GetPeersMessage.class.getSimpleName());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/network/messages/PeersMessageTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/network/messages/PeersMessageTest.java
@@ -25,8 +25,7 @@ import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.radix.serialization.SerializeMessageObject;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PeersMessageTest extends SerializeMessageObject<PeersMessage> {
 
@@ -38,7 +37,7 @@ public class PeersMessageTest extends SerializeMessageObject<PeersMessage> {
 	public void sensibleToString() {
 		String s = new PeersMessage(1, ImmutableList.of()).toString();
 
-		assertThat(s, containsString(PeersMessage.class.getSimpleName()));
+		assertThat(s).contains(PeersMessage.class.getSimpleName());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/network/messages/TestMessageTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/network/messages/TestMessageTest.java
@@ -24,8 +24,7 @@ import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.radix.serialization.SerializeMessageObject;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestMessageTest extends SerializeMessageObject<TestMessage> {
 
@@ -37,7 +36,7 @@ public class TestMessageTest extends SerializeMessageObject<TestMessage> {
 	public void sensibleToString() {
 		String s = new TestMessage().toString();
 
-		assertThat(s, containsString(TestMessage.class.getSimpleName()));
+		assertThat(s).contains(TestMessage.class.getSimpleName());
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/PeerPingMessageSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/PeerPingMessageSerializeTest.java
@@ -32,8 +32,7 @@ import org.junit.Test;
 import org.radix.network.messages.PeerPingMessage;
 import org.radix.universe.system.RadixSystem;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 /**
@@ -67,9 +66,9 @@ public class PeerPingMessageSerializeTest extends SerializeMessageObject<PeerPin
 		when(system.getNID()).thenReturn(EUID.TWO);
 		String s = new PeerPingMessage(0, 1234L, 5678L, system).toString();
 
-		assertThat(s, containsString(PeerPingMessage.class.getSimpleName()));
-		assertThat(s, containsString(EUID.TWO.toString()));
-		assertThat(s, containsString(Long.toHexString(1234)));
-		assertThat(s, containsString("5678"));
+		assertThat(s).contains(PeerPingMessage.class.getSimpleName());
+		assertThat(s).contains(EUID.TWO.toString());
+		assertThat(s).contains(Long.toHexString(1234));
+		assertThat(s).contains("5678");
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/PeerPingMessageSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/PeerPingMessageSerializeTest.java
@@ -66,9 +66,10 @@ public class PeerPingMessageSerializeTest extends SerializeMessageObject<PeerPin
 		when(system.getNID()).thenReturn(EUID.TWO);
 		String s = new PeerPingMessage(0, 1234L, 5678L, system).toString();
 
-		assertThat(s).contains(PeerPingMessage.class.getSimpleName());
-		assertThat(s).contains(EUID.TWO.toString());
-		assertThat(s).contains(Long.toHexString(1234));
-		assertThat(s).contains("5678");
+		assertThat(s)
+			.contains(PeerPingMessage.class.getSimpleName())
+			.contains(EUID.TWO.toString())
+			.contains(Long.toHexString(1234))
+			.contains("5678");
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/PeerPongMessageSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/PeerPongMessageSerializeTest.java
@@ -23,8 +23,7 @@ import org.radix.universe.system.RadixSystem;
 
 import com.radixdlt.identifiers.EUID;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 /**
@@ -45,9 +44,9 @@ public class PeerPongMessageSerializeTest extends SerializeMessageObject<PeerPon
 		when(system.getNID()).thenReturn(EUID.TWO);
 		String s = new PeerPongMessage(0, 1234L, 5678L, system).toString();
 
-		assertThat(s, containsString(PeerPongMessage.class.getSimpleName()));
-		assertThat(s, containsString(EUID.TWO.toString()));
-		assertThat(s, containsString(Long.toHexString(1234L)));
-		assertThat(s, containsString("5678"));
+		assertThat(s).contains(PeerPongMessage.class.getSimpleName());
+		assertThat(s).contains(EUID.TWO.toString());
+		assertThat(s).contains(Long.toHexString(1234L));
+		assertThat(s).contains("5678");
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/PeerPongMessageSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/PeerPongMessageSerializeTest.java
@@ -44,9 +44,10 @@ public class PeerPongMessageSerializeTest extends SerializeMessageObject<PeerPon
 		when(system.getNID()).thenReturn(EUID.TWO);
 		String s = new PeerPongMessage(0, 1234L, 5678L, system).toString();
 
-		assertThat(s).contains(PeerPongMessage.class.getSimpleName());
-		assertThat(s).contains(EUID.TWO.toString());
-		assertThat(s).contains(Long.toHexString(1234L));
-		assertThat(s).contains("5678");
+		assertThat(s)
+			.contains(PeerPongMessage.class.getSimpleName())
+			.contains(EUID.TWO.toString())
+			.contains(Long.toHexString(1234L))
+			.contains("5678");
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/PeersMessageSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/PeersMessageSerializeTest.java
@@ -56,8 +56,9 @@ public class PeersMessageSerializeTest extends SerializeMessageObject<PeersMessa
 		PeersMessage pm = new PeersMessage(1, ImmutableList.of(p));
 		String s = pm.toString();
 
-		assertThat(s).contains(PeersMessage.class.getSimpleName());
-		assertThat(s).contains(key.getPublicKey().euid().toString());
-		assertThat(s).contains("DUMMY");
+		assertThat(s)
+			.contains(PeersMessage.class.getSimpleName())
+			.contains(key.getPublicKey().euid().toString())
+			.contains("DUMMY");
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/PeersMessageSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/PeersMessageSerializeTest.java
@@ -28,8 +28,7 @@ import com.radixdlt.network.addressbook.PeerWithSystem;
 import com.radixdlt.network.transport.StaticTransportMetadata;
 import com.radixdlt.network.transport.TransportInfo;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Check serialization of PeersMessage
@@ -57,8 +56,8 @@ public class PeersMessageSerializeTest extends SerializeMessageObject<PeersMessa
 		PeersMessage pm = new PeersMessage(1, ImmutableList.of(p));
 		String s = pm.toString();
 
-		assertThat(s, containsString(PeersMessage.class.getSimpleName()));
-		assertThat(s, containsString(key.getPublicKey().euid().toString()));
-		assertThat(s, containsString("DUMMY"));
+		assertThat(s).contains(PeersMessage.class.getSimpleName());
+		assertThat(s).contains(key.getPublicKey().euid().toString());
+		assertThat(s).contains("DUMMY");
 	}
 }

--- a/radixdlt-engine/build.gradle
+++ b/radixdlt-engine/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4'
     testImplementation 'org.powermock:powermock-api-mockito2'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier'
-    testImplementation 'org.hamcrest:hamcrest-library'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'com.flipkart.zjsonpatch:zjsonpatch'
 }

--- a/radixdlt-engine/examples/build.gradle
+++ b/radixdlt-engine/examples/build.gradle
@@ -42,5 +42,4 @@ dependencies {
     implementation project(':radixdlt-engine')
 
     testImplementation 'junit:junit:4.13'
-    testImplementation 'org.hamcrest:hamcrest-library:1.3'
 }

--- a/radixdlt-engine/src/test/java/com/radixdlt/serialization/RRIParticleSerializationTest.java
+++ b/radixdlt-engine/src/test/java/com/radixdlt/serialization/RRIParticleSerializationTest.java
@@ -21,9 +21,8 @@ import com.radixdlt.TestSetupUtils;
 import com.radixdlt.atomos.RRIParticle;
 import com.radixdlt.crypto.ECKeyPair;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 
 import com.radixdlt.identifiers.RRI;
 import com.radixdlt.identifiers.RadixAddress;
@@ -64,8 +63,9 @@ public class RRIParticleSerializationTest extends SerializeObjectEngine<RRIParti
     @Test
     public void testToString() {
     	String s = get().toString();
-    	assertThat(s, containsString(RRIParticle.class.getSimpleName()));
-    	assertThat(s, containsString(rri.toString()));
+    	assertThat(s)
+    		.contains(RRIParticle.class.getSimpleName())
+    		.contains(rri.toString());
     }
 
     private static RRIParticle get() {

--- a/radixdlt-engine/src/test/java/com/radixdlt/serialization/StakedTokensParticleSerializationTest.java
+++ b/radixdlt-engine/src/test/java/com/radixdlt/serialization/StakedTokensParticleSerializationTest.java
@@ -33,9 +33,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static com.radixdlt.atommodel.tokens.MutableSupplyTokenDefinitionParticle.TokenTransition.MINT;
-import static org.hamcrest.Matchers.containsString;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class StakedTokensParticleSerializationTest extends SerializeObjectEngine<StakedTokensParticle> {
 	public static final RadixAddress DELEGATE_ADDRESS = RadixAddress.from("JEbhKQzBn4qJzWJFBbaPioA2GTeaQhuUjYWkanTE6N8VvvPpvM8");
@@ -70,9 +69,10 @@ public class StakedTokensParticleSerializationTest extends SerializeObjectEngine
 	public void testToString() {
 		StakedTokensParticle p = get();
 		String str = p.toString();
-		assertThat(str, containsString(p.getAddress().toString()));
-		assertThat(str, containsString(p.getAmount().toString()));
-		assertThat(str, containsString(p.getDelegateAddress().toString()));
+		assertThat(str)
+			.contains(p.getAddress().toString())
+			.contains(p.getAmount().toString())
+			.contains(p.getDelegateAddress().toString());
 	}
 
 	@Test

--- a/radixdlt-java-common/build.gradle
+++ b/radixdlt-java-common/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4'
     testImplementation 'org.powermock:powermock-api-mockito2'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier'
-    testImplementation 'org.hamcrest:hamcrest-library'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'com.flipkart.zjsonpatch:zjsonpatch'
     testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl'

--- a/radixdlt-java-common/src/test/java/com/radixdlt/crypto/ECKeyPairTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/crypto/ECKeyPairTest.java
@@ -17,32 +17,29 @@
 
 package com.radixdlt.crypto;
 
-import com.google.common.hash.HashCode;
-import com.radixdlt.crypto.encryption.EncryptedPrivateKey;
-import com.radixdlt.TestSetupUtils;
-import com.radixdlt.crypto.exception.ECIESException;
-import com.radixdlt.crypto.exception.PrivateKeyException;
-import com.radixdlt.crypto.exception.PublicKeyException;
-import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.hash.HashCode;
+import com.radixdlt.TestSetupUtils;
+import com.radixdlt.crypto.encryption.EncryptedPrivateKey;
+import com.radixdlt.crypto.exception.ECIESException;
+import com.radixdlt.crypto.exception.PrivateKeyException;
+import com.radixdlt.crypto.exception.PublicKeyException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class ECKeyPairTest {
 
@@ -50,9 +47,6 @@ public class ECKeyPairTest {
 	public static void beforeClass() {
 		TestSetupUtils.installBouncyCastleProvider();
 	}
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	@Test
 	public void equalsContract() {
@@ -73,8 +67,8 @@ public class ECKeyPairTest {
 
 			key = ECKeyPair.fromPrivateKey(priv);
 
-			Assert.assertArrayEquals(priv, key.getPrivateKey());
-			Assert.assertArrayEquals(pub, key.getPublicKey().getBytes());
+			assertArrayEquals(priv, key.getPrivateKey());
+			assertArrayEquals(pub, key.getPublicKey().getBytes());
 		}
 	}
 
@@ -109,7 +103,7 @@ public class ECKeyPairTest {
 			byte[] encrypted = key.getPublicKey().encrypt(helloWorld.getBytes(StandardCharsets.UTF_8));
 
 			ECKeyPair newkey = ECKeyPair.fromPrivateKey(priv);
-			Assert.assertArrayEquals(helloWorld.getBytes(StandardCharsets.UTF_8), newkey.decrypt(encrypted));
+			assertArrayEquals(helloWorld.getBytes(StandardCharsets.UTF_8), newkey.decrypt(encrypted));
 		}
 	}
 
@@ -147,7 +141,7 @@ public class ECKeyPairTest {
 		byte[] privateKey1 = ECKeyPair.generateNew().getPrivateKey();
 		byte[] privateKey2 = ECKeyPair.generateNew().getPrivateKey();
 
-		assertThat(privateKey1, not(equalTo(privateKey2)));
+		assertThat(privateKey1).isNotEqualTo(privateKey2);
 	}
 
 	@Test
@@ -156,7 +150,7 @@ public class ECKeyPairTest {
 		byte[] privateKey1 = ECKeyPair.fromSeed(seed).getPrivateKey();
 		byte[] privateKey2 = ECKeyPair.fromSeed(seed).getPrivateKey();
 
-		assertThat(privateKey1, equalTo(privateKey2));
+		assertThat(privateKey1).isEqualTo(privateKey2);
 	}
 
 	@Test
@@ -194,7 +188,7 @@ public class ECKeyPairTest {
 
 		var loadedKeyPair = ECKeyPair.fromFile(testKeyPair);
 
-		assertThat(sourceKeyPair.getPrivateKey(), equalTo(loadedKeyPair.getPrivateKey()));
+		assertThat(sourceKeyPair.getPrivateKey()).isEqualTo(loadedKeyPair.getPrivateKey());
 	}
 
 	@Test

--- a/radixdlt-java-common/src/test/java/com/radixdlt/crypto/RadixKeyStoreTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/crypto/RadixKeyStoreTest.java
@@ -33,19 +33,22 @@ import java.util.stream.IntStream;
 
 import javax.crypto.SecretKey;
 
-import com.radixdlt.crypto.exception.KeyStoreException;
-import com.radixdlt.crypto.exception.PrivateKeyException;
-import com.radixdlt.crypto.exception.PublicKeyException;
 import org.bouncycastle.jcajce.PKCS12Key;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
 import com.radixdlt.TestSetupUtils;
+import com.radixdlt.crypto.exception.KeyStoreException;
+import com.radixdlt.crypto.exception.PrivateKeyException;
+import com.radixdlt.crypto.exception.PublicKeyException;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.*;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class RadixKeyStoreTest {
 
@@ -193,8 +196,8 @@ public class RadixKeyStoreTest {
 	public void testToString() throws IOException, KeyStoreException {
 		File file = newFile(TEST_KS_FILENAME);
 		try (RadixKeyStore ks = RadixKeyStore.fromFile(file, null, true)) {
-			assertThat(ks.toString(), containsString(file.toString()));
-			assertThat(ks.toString(), containsString(RadixKeyStore.class.getSimpleName()));
+			assertThat(ks.toString()).contains(file.toString());
+			assertThat(ks.toString()).contains(RadixKeyStore.class.getSimpleName());
 		}
 	}
 

--- a/radixdlt-java-common/src/test/java/com/radixdlt/crypto/SignaturesTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/crypto/SignaturesTest.java
@@ -8,9 +8,7 @@ import java.math.BigInteger;
 import java.util.Random;
 import java.util.function.Supplier;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -46,7 +44,7 @@ public class SignaturesTest {
 
     @Test
     public void well_formatted_tostring_of_signaturescheme() {
-        assertThat(SignatureScheme.ECDSA.toString(), is("ecdsa"));
+        assertThat(SignatureScheme.ECDSA.toString()).isEqualTo("ecdsa");
     }
 
     @Test
@@ -134,8 +132,9 @@ public class SignaturesTest {
         Signatures signatures = DefaultSignatures.single(publicKey(), dummySignature);
         String tostring = signatures.toString();
 
-        assertThat(tostring, containsString(ECDSASignature.class.getSimpleName()));
-        assertThat(tostring, containsString(dummySignature.toString()));
+        assertThat(tostring)
+        	.contains(ECDSASignature.class.getSimpleName())
+        	.contains(dummySignature.toString());
     }
 
     private void test_that_we_can_bulk_verify_signatures(

--- a/radixdlt-java-common/src/test/java/com/radixdlt/crypto/SignaturesTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/crypto/SignaturesTest.java
@@ -44,7 +44,7 @@ public class SignaturesTest {
 
     @Test
     public void well_formatted_tostring_of_signaturescheme() {
-        assertThat(SignatureScheme.ECDSA.toString()).isEqualTo("ecdsa");
+        assertThat(SignatureScheme.ECDSA).hasToString("ecdsa");
     }
 
     @Test

--- a/radixdlt-java-common/src/test/java/com/radixdlt/identifiers/EUIDTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/identifiers/EUIDTest.java
@@ -17,14 +17,11 @@
 
 package com.radixdlt.identifiers;
 
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.base.Strings;
@@ -35,7 +32,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.hamcrest.number.OrderingComparison;
 import org.junit.Test;
 
 public class EUIDTest {
@@ -103,7 +99,7 @@ public class EUIDTest {
 	public void testCompare() {
 		EUID low = new EUID(Strings.repeat("1", 32));
 		EUID high = new EUID(Strings.repeat("9", 32));
-		assertThat(low, OrderingComparison.lessThan(high));
+		assertThat(low).isLessThan(high);
 	}
 
 	@Test
@@ -156,43 +152,43 @@ public class EUIDTest {
 	 */
 	@Test
 	public void testCompareDistances() {
-		assertThat(EUID.ZERO.compareDistances(EUID.ONE, EUID.ONE), is(0));
+		assertThat(EUID.ZERO.compareDistances(EUID.ONE, EUID.ONE)).isEqualTo(0);
 
 		// Both to right of origin
-		assertThat(EUID.ZERO.compareDistances(EUID.TWO, EUID.ONE), greaterThan(0));
-		assertThat(EUID.ZERO.compareDistances(EUID.ONE, EUID.TWO), lessThan(0));
+		assertThat(EUID.ZERO.compareDistances(EUID.TWO, EUID.ONE)).isGreaterThan(0);
+		assertThat(EUID.ZERO.compareDistances(EUID.ONE, EUID.TWO)).isLessThan(0);
 		EUID minusOne = new EUID(-1);
 		EUID minusTwo = new EUID(-2);
 		// Both to left of origin
-		assertThat(EUID.ZERO.compareDistances(minusTwo, minusOne), greaterThan(0));
-		assertThat(EUID.ZERO.compareDistances(minusOne, minusTwo), lessThan(0));
+		assertThat(EUID.ZERO.compareDistances(minusTwo, minusOne)).isGreaterThan(0);
+		assertThat(EUID.ZERO.compareDistances(minusOne, minusTwo)).isLessThan(0);
 
 		// Origin between values, but different in most significant bits.
-		assertThat(EUID.ZERO.compareDistances(EUID.TWO, minusOne), greaterThan(0));
-		assertThat(EUID.ZERO.compareDistances(minusOne, EUID.TWO), lessThan(0));
-		assertThat(EUID.ZERO.compareDistances(minusTwo, EUID.ONE), greaterThan(0));
-		assertThat(EUID.ZERO.compareDistances(EUID.ONE, minusTwo), lessThan(0));
+		assertThat(EUID.ZERO.compareDistances(EUID.TWO, minusOne)).isGreaterThan(0);
+		assertThat(EUID.ZERO.compareDistances(minusOne, EUID.TWO)).isLessThan(0);
+		assertThat(EUID.ZERO.compareDistances(minusTwo, EUID.ONE)).isGreaterThan(0);
+		assertThat(EUID.ZERO.compareDistances(EUID.ONE, minusTwo)).isLessThan(0);
 
 		// Origin between values, but only different in least significant bit
 		EUID three = new EUID(3L);
 		EUID minusThree = new EUID(-3L);
-		assertThat(EUID.ZERO.compareDistances(three, minusTwo), greaterThan(0));
-		assertThat(EUID.ZERO.compareDistances(minusThree, EUID.TWO), greaterThan(0));
-		assertThat(EUID.ZERO.compareDistances(minusTwo, three), lessThan(0));
-		assertThat(EUID.ZERO.compareDistances(EUID.TWO, minusThree), lessThan(0));
+		assertThat(EUID.ZERO.compareDistances(three, minusTwo)).isGreaterThan(0);
+		assertThat(EUID.ZERO.compareDistances(minusThree, EUID.TWO)).isGreaterThan(0);
+		assertThat(EUID.ZERO.compareDistances(minusTwo, three)).isLessThan(0);
+		assertThat(EUID.ZERO.compareDistances(EUID.TWO, minusThree)).isLessThan(0);
 
 		// Check that wrap / ring behaviour works
 		EUID max = new EUID(UInt128.MAX_VALUE);
 		EUID maxP2 = new EUID(UInt128.MAX_VALUE.add(UInt128.TWO));
 		EUID maxM3 = new EUID(UInt128.MAX_VALUE.subtract(UInt128.THREE));
-		assertThat(max.compareDistances(maxP2, maxM3), lessThan(0));
-		assertThat(max.compareDistances(maxM3, maxP2), greaterThan(0));
+		assertThat(max.compareDistances(maxP2, maxM3)).isLessThan(0);
+		assertThat(max.compareDistances(maxM3, maxP2)).isGreaterThan(0);
 
 		EUID min = new EUID(UInt128.MIN_VALUE);
 		EUID minP3 = new EUID(UInt128.MIN_VALUE.add(UInt128.THREE));
 		EUID minM2 = new EUID(UInt128.MIN_VALUE.subtract(UInt128.TWO));
-		assertThat(min.compareDistances(minM2, minP3), lessThan(0));
-		assertThat(min.compareDistances(minP3, minM2), greaterThan(0));
+		assertThat(min.compareDistances(minM2, minP3)).isLessThan(0);
+		assertThat(min.compareDistances(minP3, minM2)).isGreaterThan(0);
 	}
 
 	/**

--- a/radixdlt-java-common/src/test/java/com/radixdlt/identifiers/EUIDTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/identifiers/EUIDTest.java
@@ -152,43 +152,43 @@ public class EUIDTest {
 	 */
 	@Test
 	public void testCompareDistances() {
-		assertThat(EUID.ZERO.compareDistances(EUID.ONE, EUID.ONE)).isEqualTo(0);
+		assertThat(EUID.ZERO.compareDistances(EUID.ONE, EUID.ONE)).isZero();
 
 		// Both to right of origin
-		assertThat(EUID.ZERO.compareDistances(EUID.TWO, EUID.ONE)).isGreaterThan(0);
-		assertThat(EUID.ZERO.compareDistances(EUID.ONE, EUID.TWO)).isLessThan(0);
+		assertThat(EUID.ZERO.compareDistances(EUID.TWO, EUID.ONE)).isPositive();
+		assertThat(EUID.ZERO.compareDistances(EUID.ONE, EUID.TWO)).isNegative();
 		EUID minusOne = new EUID(-1);
 		EUID minusTwo = new EUID(-2);
 		// Both to left of origin
-		assertThat(EUID.ZERO.compareDistances(minusTwo, minusOne)).isGreaterThan(0);
-		assertThat(EUID.ZERO.compareDistances(minusOne, minusTwo)).isLessThan(0);
+		assertThat(EUID.ZERO.compareDistances(minusTwo, minusOne)).isPositive();
+		assertThat(EUID.ZERO.compareDistances(minusOne, minusTwo)).isNegative();
 
 		// Origin between values, but different in most significant bits.
-		assertThat(EUID.ZERO.compareDistances(EUID.TWO, minusOne)).isGreaterThan(0);
-		assertThat(EUID.ZERO.compareDistances(minusOne, EUID.TWO)).isLessThan(0);
-		assertThat(EUID.ZERO.compareDistances(minusTwo, EUID.ONE)).isGreaterThan(0);
-		assertThat(EUID.ZERO.compareDistances(EUID.ONE, minusTwo)).isLessThan(0);
+		assertThat(EUID.ZERO.compareDistances(EUID.TWO, minusOne)).isPositive();
+		assertThat(EUID.ZERO.compareDistances(minusOne, EUID.TWO)).isNegative();
+		assertThat(EUID.ZERO.compareDistances(minusTwo, EUID.ONE)).isPositive();
+		assertThat(EUID.ZERO.compareDistances(EUID.ONE, minusTwo)).isNegative();
 
 		// Origin between values, but only different in least significant bit
 		EUID three = new EUID(3L);
 		EUID minusThree = new EUID(-3L);
-		assertThat(EUID.ZERO.compareDistances(three, minusTwo)).isGreaterThan(0);
-		assertThat(EUID.ZERO.compareDistances(minusThree, EUID.TWO)).isGreaterThan(0);
-		assertThat(EUID.ZERO.compareDistances(minusTwo, three)).isLessThan(0);
-		assertThat(EUID.ZERO.compareDistances(EUID.TWO, minusThree)).isLessThan(0);
+		assertThat(EUID.ZERO.compareDistances(three, minusTwo)).isPositive();
+		assertThat(EUID.ZERO.compareDistances(minusThree, EUID.TWO)).isPositive();
+		assertThat(EUID.ZERO.compareDistances(minusTwo, three)).isNegative();
+		assertThat(EUID.ZERO.compareDistances(EUID.TWO, minusThree)).isNegative();
 
 		// Check that wrap / ring behaviour works
 		EUID max = new EUID(UInt128.MAX_VALUE);
 		EUID maxP2 = new EUID(UInt128.MAX_VALUE.add(UInt128.TWO));
 		EUID maxM3 = new EUID(UInt128.MAX_VALUE.subtract(UInt128.THREE));
-		assertThat(max.compareDistances(maxP2, maxM3)).isLessThan(0);
-		assertThat(max.compareDistances(maxM3, maxP2)).isGreaterThan(0);
+		assertThat(max.compareDistances(maxP2, maxM3)).isNegative();
+		assertThat(max.compareDistances(maxM3, maxP2)).isPositive();
 
 		EUID min = new EUID(UInt128.MIN_VALUE);
 		EUID minP3 = new EUID(UInt128.MIN_VALUE.add(UInt128.THREE));
 		EUID minM2 = new EUID(UInt128.MIN_VALUE.subtract(UInt128.TWO));
-		assertThat(min.compareDistances(minM2, minP3)).isLessThan(0);
-		assertThat(min.compareDistances(minP3, minM2)).isGreaterThan(0);
+		assertThat(min.compareDistances(minM2, minP3)).isNegative();
+		assertThat(min.compareDistances(minP3, minM2)).isPositive();
 	}
 
 	/**

--- a/radixdlt-java-common/src/test/java/com/radixdlt/utils/UInt128Test.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/utils/UInt128Test.java
@@ -17,21 +17,21 @@
 
 package com.radixdlt.utils;
 
-import static org.hamcrest.Matchers.comparesEqualTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import com.google.common.math.BigIntegerMath;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.util.Arrays;
-import nl.jqno.equalsverifier.EqualsVerifier;
+
 import org.junit.Test;
+
+import com.google.common.math.BigIntegerMath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 /**
  * Basic unit tests for {@link UInt128}.
@@ -215,18 +215,18 @@ public class UInt128Test {
 	 */
 	@Test
 	public void testCompare() {
-		assertThat(UInt128.ZERO, comparesEqualTo(UInt128.ZERO));
-		assertThat(UInt128.ZERO, lessThan(UInt128.ONE));
-		assertThat(UInt128.ZERO, lessThan(UInt128.MAX_VALUE));
-		assertThat(UInt128.MAX_VALUE, greaterThan(UInt128.ONE));
-		assertThat(UInt128.ONE, greaterThan(UInt128.ZERO));
+		assertThat(UInt128.ZERO).isEqualByComparingTo(UInt128.ZERO);
+		assertThat(UInt128.ZERO).isLessThan(UInt128.ONE);
+		assertThat(UInt128.ZERO).isLessThan(UInt128.MAX_VALUE);
+		assertThat(UInt128.MAX_VALUE).isGreaterThan(UInt128.ONE);
+		assertThat(UInt128.ONE).isGreaterThan(UInt128.ZERO);
 
 		UInt128 i63 = UInt128.from(0x0000_0000_0000_0000L, 0x8000_0000_0000_0000L);
 		UInt128 i64 = i63.add(i63);
 		UInt128 i65 = i64.add(i64);
-		assertThat(i64, greaterThan(i63)); // In case something has gone horribly wrong.
-		assertThat(i64.add(i63), greaterThan(i64));
-		assertThat(i65, greaterThan(i64.add(i63)));
+		assertThat(i64).isGreaterThan(i63); // In case something has gone horribly wrong.
+		assertThat(i64.add(i63)).isGreaterThan(i64);
+		assertThat(i65).isGreaterThan(i64.add(i63));
 	}
 
 	/**
@@ -263,9 +263,9 @@ public class UInt128Test {
 		UInt128 b0 = UInt128.ONE;
 		UInt128 b64 = UInt128.from(0x0000_0000_0000_0001L, 0x0000_0000_0000_0000);
 		// Basic sanity checks to make sure nothing is horribly wrong
-		assertThat(b64, greaterThan(b0));
-		assertThat(b0, greaterThan(UInt128.ZERO));
-		assertThat(b64, greaterThan(UInt128.ZERO));
+		assertThat(b64).isGreaterThan(b0);
+		assertThat(b0).isGreaterThan(UInt128.ZERO);
+		assertThat(b64).isGreaterThan(UInt128.ZERO);
 
 		// Now for the real tests
 		assertEquals(b0, UInt128.ZERO.or(b0));

--- a/radixdlt-java-common/src/test/java/com/radixdlt/utils/UInt128Test.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/utils/UInt128Test.java
@@ -215,9 +215,10 @@ public class UInt128Test {
 	 */
 	@Test
 	public void testCompare() {
-		assertThat(UInt128.ZERO).isEqualByComparingTo(UInt128.ZERO);
-		assertThat(UInt128.ZERO).isLessThan(UInt128.ONE);
-		assertThat(UInt128.ZERO).isLessThan(UInt128.MAX_VALUE);
+		assertThat(UInt128.ZERO)
+			.isEqualByComparingTo(UInt128.ZERO)
+			.isLessThan(UInt128.ONE)
+			.isLessThan(UInt128.MAX_VALUE);
 		assertThat(UInt128.MAX_VALUE).isGreaterThan(UInt128.ONE);
 		assertThat(UInt128.ONE).isGreaterThan(UInt128.ZERO);
 

--- a/radixdlt-java-common/src/test/java/com/radixdlt/utils/UInt256Test.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/utils/UInt256Test.java
@@ -253,9 +253,10 @@ public class UInt256Test {
 
 	@Test
 	public void when_comparing_int256_values_using_compareTo__the_correct_value_is_returned() {
-		assertThat(UInt256.ZERO).isEqualByComparingTo(UInt256.ZERO);
-		assertThat(UInt256.ZERO).isLessThan(UInt256.ONE);
-		assertThat(UInt256.ZERO).isLessThan(UInt256.MAX_VALUE);
+		assertThat(UInt256.ZERO)
+			.isEqualByComparingTo(UInt256.ZERO)
+			.isLessThan(UInt256.ONE)
+			.isLessThan(UInt256.MAX_VALUE);
 		assertThat(UInt256.ONE).isGreaterThan(UInt256.ZERO);
 		assertThat(UInt256.MAX_VALUE).isGreaterThan(UInt256.ZERO);
 

--- a/radixdlt-java-common/src/test/java/com/radixdlt/utils/UInt256Test.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/utils/UInt256Test.java
@@ -17,22 +17,22 @@
 
 package com.radixdlt.utils;
 
-import static org.hamcrest.Matchers.comparesEqualTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import com.google.common.math.BigIntegerMath;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.util.Arrays;
-import nl.jqno.equalsverifier.EqualsVerifier;
+
 import org.junit.Test;
+
+import com.google.common.math.BigIntegerMath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 /**
  * Basic unit tests for {@link UInt256}.
@@ -253,18 +253,18 @@ public class UInt256Test {
 
 	@Test
 	public void when_comparing_int256_values_using_compareTo__the_correct_value_is_returned() {
-		assertThat(UInt256.ZERO, comparesEqualTo(UInt256.ZERO));
-		assertThat(UInt256.ZERO, lessThan(UInt256.ONE));
-		assertThat(UInt256.ZERO, lessThan(UInt256.MAX_VALUE));
-		assertThat(UInt256.ONE, greaterThan(UInt256.ZERO));
-		assertThat(UInt256.MAX_VALUE, greaterThan(UInt256.ZERO));
+		assertThat(UInt256.ZERO).isEqualByComparingTo(UInt256.ZERO);
+		assertThat(UInt256.ZERO).isLessThan(UInt256.ONE);
+		assertThat(UInt256.ZERO).isLessThan(UInt256.MAX_VALUE);
+		assertThat(UInt256.ONE).isGreaterThan(UInt256.ZERO);
+		assertThat(UInt256.MAX_VALUE).isGreaterThan(UInt256.ZERO);
 
 		UInt256 i127 = UInt256.from(UInt128.ZERO, UInt128.HIGH_BIT);
 		UInt256 i128 = i127.add(i127);
 		UInt256 i129 = i128.add(i128);
-		assertThat(i128, greaterThan(i127)); // In case something has gone horribly wrong.
-		assertThat(i128.add(i127), greaterThan(i128));
-		assertThat(i129, greaterThan(i128.add(i127)));
+		assertThat(i128).isGreaterThan(i127); // In case something has gone horribly wrong.
+		assertThat(i128.add(i127)).isGreaterThan(i128);
+		assertThat(i129).isGreaterThan(i128.add(i127));
 	}
 
 	@Test
@@ -292,9 +292,9 @@ public class UInt256Test {
 		UInt256 b0 = UInt256.ONE;
 		UInt256 b128 = UInt256.from(UInt128.ONE, UInt128.ZERO);
 		// Basic sanity checks to make sure nothing is horribly wrong
-		assertThat(b128, greaterThan(b0));
-		assertThat(b0, greaterThan(UInt256.ZERO));
-		assertThat(b128, greaterThan(UInt256.ZERO));
+		assertThat(b128).isGreaterThan(b0);
+		assertThat(b0).isGreaterThan(UInt256.ZERO);
+		assertThat(b128).isGreaterThan(UInt256.ZERO);
 
 		// Now for the real tests
 		assertEquals(b0, UInt256.ZERO.or(b0));

--- a/radixdlt-java-common/src/test/java/com/radixdlt/utils/UInt384Test.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/utils/UInt384Test.java
@@ -260,9 +260,10 @@ public class UInt384Test {
 
 	@Test
 	public void when_comparing_int384_values_using_compareTo__the_correct_value_is_returned() {
-		assertThat(UInt384.ZERO).isEqualByComparingTo(UInt384.ZERO);
-		assertThat(UInt384.ZERO).isLessThan(UInt384.ONE);
-		assertThat(UInt384.ZERO).isLessThan(UInt384.MAX_VALUE);
+		assertThat(UInt384.ZERO)
+			.isEqualByComparingTo(UInt384.ZERO)
+			.isLessThan(UInt384.ONE)
+			.isLessThan(UInt384.MAX_VALUE);
 		assertThat(UInt384.ONE).isGreaterThan(UInt384.ZERO);
 		assertThat(UInt384.MAX_VALUE).isGreaterThan(UInt384.ZERO);
 

--- a/radixdlt-java-common/src/test/java/com/radixdlt/utils/UInt384Test.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/utils/UInt384Test.java
@@ -17,22 +17,22 @@
 
 package com.radixdlt.utils;
 
-import static org.hamcrest.Matchers.comparesEqualTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import com.google.common.math.BigIntegerMath;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.util.Arrays;
-import nl.jqno.equalsverifier.EqualsVerifier;
+
 import org.junit.Test;
+
+import com.google.common.math.BigIntegerMath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 /**
  * Basic unit tests for {@link UInt384}.
@@ -260,18 +260,18 @@ public class UInt384Test {
 
 	@Test
 	public void when_comparing_int384_values_using_compareTo__the_correct_value_is_returned() {
-		assertThat(UInt384.ZERO, comparesEqualTo(UInt384.ZERO));
-		assertThat(UInt384.ZERO, lessThan(UInt384.ONE));
-		assertThat(UInt384.ZERO, lessThan(UInt384.MAX_VALUE));
-		assertThat(UInt384.ONE, greaterThan(UInt384.ZERO));
-		assertThat(UInt384.MAX_VALUE, greaterThan(UInt384.ZERO));
+		assertThat(UInt384.ZERO).isEqualByComparingTo(UInt384.ZERO);
+		assertThat(UInt384.ZERO).isLessThan(UInt384.ONE);
+		assertThat(UInt384.ZERO).isLessThan(UInt384.MAX_VALUE);
+		assertThat(UInt384.ONE).isGreaterThan(UInt384.ZERO);
+		assertThat(UInt384.MAX_VALUE).isGreaterThan(UInt384.ZERO);
 
 		UInt384 i127 = UInt384.from(UInt128.ZERO, UInt256.HIGH_BIT);
 		UInt384 i128 = i127.add(i127);
 		UInt384 i129 = i128.add(i128);
-		assertThat(i128, greaterThan(i127)); // In case something has gone horribly wrong.
-		assertThat(i128.add(i127), greaterThan(i128));
-		assertThat(i129, greaterThan(i128.add(i127)));
+		assertThat(i128).isGreaterThan(i127); // In case something has gone horribly wrong.
+		assertThat(i128.add(i127)).isGreaterThan(i128);
+		assertThat(i129).isGreaterThan(i128.add(i127));
 	}
 
 	@Test
@@ -300,9 +300,9 @@ public class UInt384Test {
 		UInt384 b0 = UInt384.ONE;
 		UInt384 b128 = UInt384.from(UInt128.ONE, UInt256.ZERO);
 		// Basic sanity checks to make sure nothing is horribly wrong
-		assertThat(b128, greaterThan(b0));
-		assertThat(b0, greaterThan(UInt384.ZERO));
-		assertThat(b128, greaterThan(UInt384.ZERO));
+		assertThat(b128).isGreaterThan(b0);
+		assertThat(b0).isGreaterThan(UInt384.ZERO);
+		assertThat(b128).isGreaterThan(UInt384.ZERO);
 
 		// Now for the real tests
 		assertEquals(b0, UInt384.ZERO.or(b0));

--- a/radixdlt-java/radixdlt-java/build.gradle
+++ b/radixdlt-java/radixdlt-java/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     testImplementation 'junit:junit'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.assertj:assertj-core'
-    testImplementation 'org.hamcrest:hamcrest-library'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier'
     testImplementation 'com.flipkart.zjsonpatch:zjsonpatch'
 }


### PR DESCRIPTION
Replaced JUnit `assertThat(...)` with AssertJ `assertThat(...)`.  Note that the JUnit method is now deprecated, and this change makes our unit tests more uniform.

Added missing Override annotations for various methods in the new interoperability test suite.

Removed some unused loggers.

Slightly modified one use of a method reference into a lambda that will compile with the Eclipse compiler.