### PR TITLE
Fixed links in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# radixdlt-parent
+# radixdlt
+
+This is the monorepo for consensus, networking and Java client library for the [Radix DLT](https://www.radixdlt.com)
+Distributed Ledger.
+
+It includes a variant implementation of the [HotStuff](https://arxiv.org/abs/1803.05069) BFT-style consensus.
+
+## Table of contents
+
+- [Subdirectories](#subdirectories)
+- [Contribute](#contribute)
+- [Links](#links)
+- [License](#license)
+
+## Subdirectories
+Here we have:
+
+- [radixdlt-core](radixdlt-core/README.md): The core consensus and networking modules
+- [radixdlt-engine](radixdlt-engine/README.md): The Radix execution environment which provides an engine for a real-time, distributed state machine
+- [radixdlt-java-common](radixdlt-java-common/README.md): Common Java utilities used by various modules
+- [radixdlt-java](radixdlt-java/README.md): The Java client access library
+
+## Contribute
+
+[Contributions](CONTRIBUTING.md) are welcome, we simply ask to:
+
+* Fork the codebase
+* Make changes
+* Submit a pull request for review
+
+When contributing to this repository, we recommend discussing with the development team the change you wish to make using a [GitHub issue](https://github.com/radixdlt/radixdlt/issues) before making changes.
+
+Please follow our [Code of Conduct](CODE_OF_CONDUCT.md) in all your interactions with the project.
+
+## Links
+
+| Link | Description |
+| :----- | :------ |
+[radixdlt.com](https://radixdlt.com/) | Radix DLT Homepage
+[documentation](https://docs.radixdlt.com/) | Radix Knowledge Base
+[forum](https://forum.radixdlt.com/) | Radix Technical Forum
+[@radixdlt](https://twitter.com/radixdlt) | Follow Radix DLT on Twitter
+
+## License
+
+The `radixdlt-core`, `radixdlt-engine` and `radixdlt-java-common` code is released under the [Apache 2.0 License](LICENSE).
+
+The `radixdlt-java` library is released under the [MIT License](radixdlt-java/LICENSE).

--- a/radixdlt-core/README.md
+++ b/radixdlt-core/README.md
@@ -14,12 +14,12 @@ Distributed Ledger. It includes a variant implementation of the [HotStuff](https
 ## Building
 Clone the required repository:
 ```
-git clone https://github.com/radixdlt/radixdlt-core.git
+git clone https://github.com/radixdlt/radixdlt.git
 ```
 
 Checkout the required branch:
 ```
-cd radixdlt-core && git checkout release/1.0-beta.21
+cd radixdlt && git checkout release/1.0-beta.22
 ```
 
 Run tests (note that integration tests take several minutes to run):
@@ -54,21 +54,21 @@ API interface can be accessed via localhost:8080, eg:
 curl localhost:8080/api/universe
 ```
 
-See also [radixdlt-java](https://github.com/radixdlt/radixdlt-java)
+See also [radixdlt-java](../radixdlt-java)
 for a Java client library and [radixdlt-js](https://github.com/radixdlt/radixdlt-js)
 for Javascript.
 
 ## Contribute
 
-[Contributions](CONTRIBUTING.md) are welcome, we simply ask to:
+[Contributions](../CONTRIBUTING.md) are welcome, we simply ask to:
 
 * Fork the codebase
 * Make changes
 * Submit a pull request for review
 
-When contributing to this repository, we recommend discussing with the development team the change you wish to make using a [GitHub issue](https://github.com/radixdlt/radixdlt-core/issues) before making changes.
+When contributing to this repository, we recommend discussing with the development team the change you wish to make using a [GitHub issue](https://github.com/radixdlt/radixdlt/issues) before making changes.
 
-Please follow our [Code of Conduct](CODE_OF_CONDUCT.md) in all your interactions with the project.
+Please follow our [Code of Conduct](../CODE_OF_CONDUCT.md) in all your interactions with the project.
 
 ## Links
 
@@ -81,4 +81,4 @@ Please follow our [Code of Conduct](CODE_OF_CONDUCT.md) in all your interactions
 
 ## License
 
-The `radixdlt-core` code is released under the [Apache 2.0 License](LICENSE).
+The `radixdlt-core` code is released under the [Apache 2.0 License](../LICENSE).

--- a/radixdlt-engine/README.md
+++ b/radixdlt-engine/README.md
@@ -20,9 +20,9 @@ Contributions are welcome, we simply ask to:
 When contributing to this repository, we recommend to discuss the change you wish to make via issue,
 email, or any other method with the owners of this repository before making a change. 
 
-Please follow our [Code of Conduct](CODE_OF_CONDUCT.md) in all your interactions with the project.
+Please follow our [Code of Conduct](../CODE_OF_CONDUCT.md) in all your interactions with the project.
 
 ## License
 
-radix-engine-library is released under the [Apache 2.0 License](LICENSE).
+radix-engine-library is released under the [Apache 2.0 License](../LICENSE).
 

--- a/radixdlt-java-common/README.md
+++ b/radixdlt-java-common/README.md
@@ -4,4 +4,4 @@ Java common library with utilities shared by all our Java libraries, such as:
 * Hashing  
 * Crypto  
 
-(Not to be confused with our Java/Android Client library repo [`radixdlt-java`](https://github.com/radixdlt/radixdlt-java), which uses this common utilities repo)
+(Not to be confused with our Java/Android Client library repo [`radixdlt-java`](../radixdlt-java), which uses this common utilities repo)

--- a/radixdlt-java/README.md
+++ b/radixdlt-java/README.md
@@ -49,7 +49,7 @@ as well as decrypt data.
 
 To create/load an identity from a file:
 ```java
-RadixIdentity identity = RadixIdentities.loadOrCreateEncryptedFile("filename.key", "password123");
+RadixIdentity identity = RadixIdentities.loadOrCreateEncryptedFile("filename.key", "password123", "key_name");
 ```
 This will either create or load a file with a public/private key and encrypted with the given password.
 
@@ -255,15 +255,15 @@ result.blockUntilComplete();
 
 ## Contribute
 
-[Contributions](CONTRIBUTING.md) are welcome, we simply ask to:
+[Contributions](../CONTRIBUTING.md) are welcome, we simply ask to:
 
 * Fork the codebase
 * Make changes
 * Submit a pull request for review
 
-When contributing to this repository, we recommend discussing with the development team the change you wish to make using a [GitHub issue](https://github.com/radixdlt/radixdlt-java/issues) before making changes.
+When contributing to this repository, we recommend discussing with the development team the change you wish to make using a [GitHub issue](https://github.com/radixdlt/radixdlt/issues) before making changes.
 
-Please follow our [Code of Conduct](CODE_OF_CONDUCT.md) in all your interactions with the project.
+Please follow our [Code of Conduct](../CODE_OF_CONDUCT.md) in all your interactions with the project.
 
 ## Links
 


### PR DESCRIPTION
After refactoring the multiple repositories to a monorepo,
links in the READMEs were not updated to reflect the changes.