### PR TITLE
Fixed null error if validatorSet was not set with BFTBuilder

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/bft/BFTBuilder.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/bft/BFTBuilder.java
@@ -119,7 +119,7 @@ public final class BFTBuilder {
 	}
 
 	public BFTEventProcessor build() {
-		if (!validatorSet.containsNode(self)) {
+		if (validatorSet == null || !validatorSet.containsNode(self)) {
 			return EmptyBFTEventProcessor.INSTANCE;
 		}
 		final PendingVotes pendingVotes = new PendingVotes(hasher);


### PR DESCRIPTION
Would it be better to just throw an exception if validatorSet is null ?