### PR TITLE
Further develop sanity test suite

### DIFF
--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/SanityTestSuiteExecutor.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/SanityTestSuiteExecutor.java
@@ -20,6 +20,7 @@ package com.radixdlt.sanitytestsuite;
 import com.google.common.collect.ImmutableList;
 import com.radixdlt.sanitytestsuite.model.SanityTestSuiteRoot;
 import com.radixdlt.sanitytestsuite.scenario.SanityTestScenarioRunner;
+import com.radixdlt.sanitytestsuite.scenario.deserialization.DeserializationTestScenarioRunner;
 import com.radixdlt.sanitytestsuite.scenario.hashing.HashingTestScenarioRunner;
 import com.radixdlt.sanitytestsuite.scenario.jsondeserialization.JsonDeserializationTestScenarioRunner;
 import com.radixdlt.sanitytestsuite.scenario.jsonserialization.JsonSerializationTestScenarioRunner;
@@ -27,6 +28,7 @@ import com.radixdlt.sanitytestsuite.scenario.keygen.KeyGenTestScenarioRunner;
 import com.radixdlt.sanitytestsuite.scenario.keysign.KeySignTestScenarioRunner;
 import com.radixdlt.sanitytestsuite.scenario.keyverify.KeyVerifyTestScenarioRunner;
 import com.radixdlt.sanitytestsuite.scenario.radixhashing.RadixHashingTestScenarioRunner;
+import com.radixdlt.sanitytestsuite.scenario.serialization.SerializationTestScenarioRunner;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Test;
@@ -39,7 +41,7 @@ import java.util.stream.Collectors;
 import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertEquals;
 
-public final class Executor {
+public final class SanityTestSuiteExecutor {
 	private static final Logger LOG = LogManager.getLogger();
 	private static final String SANITY_TEST_SUITE_JSON_FILE_NAME = "sanity_test_suite.json";
 
@@ -49,8 +51,8 @@ public final class Executor {
 		new KeyGenTestScenarioRunner(),
 		new KeySignTestScenarioRunner(),
 		new KeyVerifyTestScenarioRunner(),
-		new JsonSerializationTestScenarioRunner(),
-		new JsonDeserializationTestScenarioRunner()
+		new SerializationTestScenarioRunner(),
+		new DeserializationTestScenarioRunner()
 	);
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/model/SanityTestSuiteRoot.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/model/SanityTestSuiteRoot.java
@@ -127,7 +127,10 @@ public final class SanityTestSuiteRoot {
 						this.description.troubleshooting,
 						this.description.implementationInfo,
 						this.tests.source.link,
-						this.tests.source.modifiedByTool == null ? "NO" : "YES, modified with tool (see 'expression' for how): " + this.tests.source.modifiedByTool.tool.link,
+						this.tests.source.modifiedByTool == null
+							? "NO"
+							: "YES, modified with tool (see 'expression' for how): "
+							  + this.tests.source.modifiedByTool.tool.link,
 						testAssertionError.getLocalizedMessage()
 				);
 			}

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/model/SanityTestVector.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/model/SanityTestVector.java
@@ -19,6 +19,8 @@ package com.radixdlt.sanitytestsuite.model;
 
 // CHECKSTYLE:OFF checkstyle:VisibilityModifier
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * Sanity test vector interface.
  * @param <I> - type of input value

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/deserialization/DeserializationTestScenarioRunner.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/deserialization/DeserializationTestScenarioRunner.java
@@ -1,0 +1,223 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.sanitytestsuite.scenario.deserialization;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.radixdlt.DefaultSerialization;
+import com.radixdlt.atommodel.system.SystemParticle;
+import com.radixdlt.atommodel.tokens.FixedSupplyTokenDefinitionParticle;
+import com.radixdlt.atommodel.tokens.MutableSupplyTokenDefinitionParticle;
+import com.radixdlt.atommodel.tokens.TransferrableTokensParticle;
+import com.radixdlt.atommodel.tokens.UnallocatedTokensParticle;
+import com.radixdlt.atommodel.tokens.StakedTokensParticle;
+import com.radixdlt.atommodel.validators.RegisteredValidatorParticle;
+import com.radixdlt.atommodel.validators.UnregisteredValidatorParticle;
+import com.radixdlt.atomos.RRIParticle;
+import com.radixdlt.constraintmachine.Particle;
+import com.radixdlt.sanitytestsuite.scenario.SanityTestScenarioRunner;
+import com.radixdlt.sanitytestsuite.utility.ArgumentsExtractor;
+import com.radixdlt.serialization.DeserializeException;
+import com.radixdlt.serialization.Serialization;
+import org.bouncycastle.util.encoders.Hex;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import static java.util.Optional.ofNullable;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public final class DeserializationTestScenarioRunner extends SanityTestScenarioRunner<DeserializationTestVector> {
+
+	private final static Serialization serialization = DefaultSerialization.getInstance();
+	private final ObjectMapper mapper = new ObjectMapper();
+
+	private static ImmutableMap<String, BiConsumer<Map<String, Object>, Object>> assertEqualsMap;
+
+	public DeserializationTestScenarioRunner() {
+		Map<String, BiConsumer<Map<String, Object>, Object>> mutableMap = Maps.newHashMap();
+		mutableMap.put("radix.particles.transferrable_tokens", DeserializationTestScenarioRunner::assertTransferableTokensParticle);
+		mutableMap.put("radix.particles.fixed_supply_token_definition", DeserializationTestScenarioRunner::assertFixedSupplyTokenDefinitionParticle);
+		mutableMap.put("radix.particles.mutable_supply_token_definition", DeserializationTestScenarioRunner::assertMutableSupplyTokenDefinitionParticle);
+		mutableMap.put("radix.particles.staked_tokens", DeserializationTestScenarioRunner::assertStakedTokensParticle);
+		mutableMap.put("radix.particles.unallocated_tokens", DeserializationTestScenarioRunner::assertUnallocatedTokensParticle);
+		mutableMap.put("radix.particles.rri", DeserializationTestScenarioRunner::assertRRIParticle);
+		mutableMap.put("radix.particles.registered_validator", DeserializationTestScenarioRunner::assertRegisteredValidatorParticle);
+		mutableMap.put("radix.particles.unregistered_validator", DeserializationTestScenarioRunner::assertUnregisteredValidatorParticle);
+		mutableMap.put("radix.particles.system_tokens", DeserializationTestScenarioRunner::assertSystemParticle);
+		assertEqualsMap = ImmutableMap.copyOf(mutableMap);
+	}
+
+	@Override
+	public String testScenarioIdentifier() {
+		return "deserialization_radix_models";
+	}
+
+	@Override
+	public Class<DeserializationTestVector> testVectorType() {
+		return DeserializationTestVector.class;
+	}
+
+	@Override
+	public void doRunTestVector(DeserializationTestVector testVector) throws AssertionError {
+		var assertEqualModel = ofNullable(
+				assertEqualsMap.get(testVector.input.typeSerialization)
+		).orElseThrow(() -> new IllegalStateException("Can't find assertEqualModel method"));
+
+		var deserializedModel = ofNullable(testVector.input.json)
+				.map(jsonMap -> {
+					try {
+						return mapper.writeValueAsString(jsonMap);
+					} catch (JsonProcessingException e) {
+						throw new IllegalStateException("Failed to create JSON string from JSON object.");
+					}
+				})
+				.map(jsonString -> {
+					try {
+						return serialization.fromJson(jsonString, serialization.getClassForId(testVector.input.typeSerialization));
+					} catch (DeserializeException e) {
+						throw new AssertionError("Failed to deserialize model from JSON string.", e);
+					}
+				}).orElseThrow(() -> new IllegalStateException("Can't deserialize model"));
+
+		assertEqualModel.accept(
+				testVector.expected.arguments,
+				deserializedModel
+		);
+
+		assertEqualDson(testVector, deserializedModel, Particle.class);
+	}
+
+	private static void assertEqualDson(DeserializationTestVector testVector, Object deserializedModel, Class<? extends Particle> classToDeserializeAs) {
+		try {
+			byte[] dsonAllOutput = Hex.decode(testVector.input.dson.get("allOutputHex").toString());
+			Particle particleDeserializedFromAllOutput = serialization.fromDson(dsonAllOutput, classToDeserializeAs);
+			assertEquals(deserializedModel, particleDeserializedFromAllOutput);
+			byte[] dsonHashOutput = Hex.decode(testVector.input.dson.get("hashOutputHex").toString());
+			Particle particleDeserializedFromHashOutput = serialization.fromDson(dsonHashOutput, classToDeserializeAs);
+			assertEquals(deserializedModel, particleDeserializedFromHashOutput);
+		} catch(DeserializeException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static void assertTransferableTokensParticle(final Map<String, Object> arguments, final Object expectedObject) {
+		TransferrableTokensParticle expected = (TransferrableTokensParticle) expectedObject;
+		ArgumentsExtractor argsExtractor = ArgumentsExtractor.from(arguments);
+
+		assertEquals(expected.getAddress(), argsExtractor.asRadixAddress("address"));
+		assertEquals(expected.getAmount(), argsExtractor.asUInt256("amount"));
+		assertEquals(expected.getGranularity(), argsExtractor.asUInt256("granularity"));
+		assertEquals(expected.getTokDefRef(), argsExtractor.asRRI("tokenDefinitionReference"));
+		assertEquals(expected.getNonce(), argsExtractor.asLong("nonce"));
+		assertEquals(expected.getTokenPermissions(), argsExtractor.extractTokenPermissions("tokenPermissions"));
+
+		assertTrue(argsExtractor.isFinished());
+
+	}
+
+	private static void assertFixedSupplyTokenDefinitionParticle(final Map<String, Object> arguments, final Object expectedObject) {
+		FixedSupplyTokenDefinitionParticle expected = (FixedSupplyTokenDefinitionParticle) expectedObject;
+		ArgumentsExtractor argsExtractor = ArgumentsExtractor.from(arguments);
+
+		assertEquals(expected.getGranularity(), argsExtractor.asUInt256("granularity"));
+		assertEquals(expected.getRRI(), argsExtractor.asRRI("rri"));
+		assertEquals(expected.getName(), argsExtractor.asString("name"));
+		assertEquals(expected.getDescription(), argsExtractor.asString("description"));
+		assertEquals(expected.getIconUrl(), argsExtractor.asString("iconUrl"));
+		assertEquals(expected.getSupply(), argsExtractor.asUInt256("supply"));
+		assertEquals(expected.getUrl(), argsExtractor.asString("url"));
+
+		assertTrue(argsExtractor.isFinished());
+	}
+
+	private static void assertMutableSupplyTokenDefinitionParticle(final Map<String, Object> arguments, final Object expectedObject) {
+		MutableSupplyTokenDefinitionParticle expected = (MutableSupplyTokenDefinitionParticle) expectedObject;
+		ArgumentsExtractor argsExtractor = ArgumentsExtractor.from(arguments);
+
+		assertEquals(expected.getGranularity(), argsExtractor.asUInt256("granularity"));
+		assertEquals(expected.getRRI(), argsExtractor.asRRI("rri"));
+		assertEquals(expected.getName(), argsExtractor.asString("name"));
+		assertEquals(expected.getDescription(), argsExtractor.asString("description"));
+		assertEquals(expected.getIconUrl(), argsExtractor.asString("iconUrl"));
+		assertEquals(expected.getUrl(), argsExtractor.asString("url"));
+
+		assertTrue(argsExtractor.isFinished());
+	}
+
+	private static void assertStakedTokensParticle(final Map<String, Object> arguments, final Object expectedObject) {
+		StakedTokensParticle expected = (StakedTokensParticle) expectedObject;
+		ArgumentsExtractor argsExtractor = ArgumentsExtractor.from(arguments);
+
+		assertEquals(expected.getAmount(), argsExtractor.asUInt256("amount"));
+		assertEquals(expected.getAddress(), argsExtractor.asRadixAddress("address"));
+		assertEquals(expected.getGranularity(), argsExtractor.asUInt256("granularity"));
+		assertEquals(expected.getTokenPermissions(), argsExtractor.extractTokenPermissions("tokenPermissions"));
+		assertEquals(expected.getDelegateAddress(), argsExtractor.asRadixAddress("delegateAddress"));
+		assertEquals(expected.getNonce(), argsExtractor.asLong("nonce"));
+		assertEquals(expected.getTokDefRef(), argsExtractor.asRRI("tokenDefinitionReference"));
+
+		assertTrue(argsExtractor.isFinished());
+	}
+
+	private static void assertUnallocatedTokensParticle(final Map<String, Object> arguments, final Object expectedObject) {
+		UnallocatedTokensParticle expected = (UnallocatedTokensParticle) expectedObject;
+		ArgumentsExtractor argsExtractor = ArgumentsExtractor.from(arguments);
+
+		assertEquals(expected.getAmount(), argsExtractor.asUInt256("amount"));
+		assertEquals(expected.getGranularity(), argsExtractor.asUInt256("granularity"));
+		assertEquals(expected.getTokDefRef(), argsExtractor.asRRI("tokenDefinitionReference"));
+		assertEquals(expected.getNonce(), argsExtractor.asLong("nonce"));
+		assertEquals(expected.getTokenPermissions(), argsExtractor.extractTokenPermissions("tokenPermissions"));
+
+		assertTrue(argsExtractor.isFinished());
+	}
+
+	private static void assertRRIParticle(final Map<String, Object> arguments, final Object expectedObject) {
+		RRIParticle expected = (RRIParticle) expectedObject;
+		ArgumentsExtractor argsExtractor = ArgumentsExtractor.from(arguments);
+
+		assertTrue(argsExtractor.isFinished());
+	}
+
+	private static void assertRegisteredValidatorParticle(final Map<String, Object> arguments, final Object expectedObject) {
+		RegisteredValidatorParticle expected = (RegisteredValidatorParticle) expectedObject;
+		ArgumentsExtractor argsExtractor = ArgumentsExtractor.from(arguments);
+
+		assertTrue(argsExtractor.isFinished());
+	}
+
+	private static void assertUnregisteredValidatorParticle(final Map<String, Object> arguments, final Object expectedObject) {
+		UnregisteredValidatorParticle expected = (UnregisteredValidatorParticle) expectedObject;
+		ArgumentsExtractor argsExtractor = ArgumentsExtractor.from(arguments);
+
+		assertTrue(argsExtractor.isFinished());
+	}
+
+	private static void assertSystemParticle(final Map<String, Object> arguments, final Object expectedObject) {
+		SystemParticle expected = (SystemParticle) expectedObject;
+		ArgumentsExtractor argsExtractor = ArgumentsExtractor.from(arguments);
+
+		assertTrue(argsExtractor.isFinished());
+	}
+
+}
+

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/deserialization/DeserializationTestVector.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/deserialization/DeserializationTestVector.java
@@ -1,0 +1,40 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.sanitytestsuite.scenario.deserialization;
+
+
+import com.radixdlt.sanitytestsuite.model.SanityTestVector;
+
+import java.util.Map;
+
+import static com.radixdlt.sanitytestsuite.scenario.deserialization.DeserializationTestVector.Expected;
+import static com.radixdlt.sanitytestsuite.scenario.deserialization.DeserializationTestVector.Input;
+
+// CHECKSTYLE:OFF checkstyle:VisibilityModifier
+public final class DeserializationTestVector extends SanityTestVector<Input, Expected> {
+	public static final class Expected {
+		public Map<String, Object> arguments;
+	}
+
+	public static final class Input {
+		public Map<String, Object> json;
+		public Map<String, Object> dson;
+		public String typeSerialization;
+	}
+}
+// CHECKSTYLE:ON

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/serialization/SerializationTestScenarioRunner.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/serialization/SerializationTestScenarioRunner.java
@@ -1,0 +1,91 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.sanitytestsuite.scenario.serialization;
+
+import com.google.common.collect.ImmutableMap;
+import com.radixdlt.DefaultSerialization;
+import com.radixdlt.atommodel.tokens.TransferrableTokensParticle;
+import com.radixdlt.sanitytestsuite.scenario.SanityTestScenarioRunner;
+import com.radixdlt.sanitytestsuite.utility.ArgumentsExtractor;
+import com.radixdlt.serialization.DsonOutput;
+import com.radixdlt.serialization.Serialization;
+import com.radixdlt.utils.JSONFormatter;
+import org.bouncycastle.util.encoders.Hex;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import static java.util.Optional.ofNullable;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public final class SerializationTestScenarioRunner extends SanityTestScenarioRunner<SerializationTestVector> {
+	private final Serialization serialization = DefaultSerialization.getInstance();
+
+	@Override
+	public String testScenarioIdentifier() {
+		return "serialization_radix_models";
+	}
+
+	@Override
+	public Class<SerializationTestVector> testVectorType() {
+		return SerializationTestVector.class;
+	}
+
+	private static TransferrableTokensParticle makeTransferrableTokensParticle(final Map<String, Object> arguments) {
+		var argsExtractor = ArgumentsExtractor.from(arguments);
+
+		var ttp = new TransferrableTokensParticle(
+			argsExtractor.asRadixAddress("address"),
+			argsExtractor.asUInt256("amount"),
+			argsExtractor.asUInt256("granularity"),
+			argsExtractor.asRRI("tokenDefinitionReference"),
+			argsExtractor.extractTokenPermissions("tokenPermissions"),
+			argsExtractor.asLong("nonce")
+		);
+
+		assertTrue(argsExtractor.isFinished());
+
+		return ttp;
+	}
+
+	private static final Map<String, Function<Map<String, Object>, Object>> constructorMap = ImmutableMap.of(
+		"radix.particles.transferrable_tokens", SerializationTestScenarioRunner::makeTransferrableTokensParticle
+	);
+
+	@Override
+	public void doRunTestVector(SerializationTestVector testVector) throws AssertionError {
+		var produced = ofNullable(constructorMap.get(testVector.input.typeSerialization))
+			.map(constructor -> constructor.apply(testVector.input.arguments))
+			.map(model -> {
+				String expectedDsonAllHex = testVector.expected.dson.get("allOutputHex").toString();
+				String expectedDsonHashHex = testVector.expected.dson.get("hashOutputHex").toString();
+				String dsonAllHex = Hex.toHexString(serialization.toDson(model, DsonOutput.Output.ALL));
+				String dsonHashHex = Hex.toHexString(serialization.toDson(model, DsonOutput.Output.HASH));
+				assertEquals("DSON (all) mismatch", expectedDsonAllHex, dsonAllHex);
+				assertEquals("DSON (hash) mismatch", expectedDsonHashHex, dsonHashHex);
+				return model;
+			})
+			.map(model -> serialization.toJson(model, DsonOutput.Output.HASH))
+			.map(JSONFormatter::sortPrettyPrintJSONString)
+			.orElseThrow(() -> new IllegalStateException("Cant find constructor for " + testVector.input.typeSerialization));
+		String expected = JSONFormatter.sortPrettyPrintJSONString(testVector.expected.jsonPrettyPrinted);
+		assertEquals(expected, produced);
+	}
+
+}

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/serialization/SerializationTestVector.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sanitytestsuite/scenario/serialization/SerializationTestVector.java
@@ -1,0 +1,39 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.sanitytestsuite.scenario.serialization;
+
+import com.radixdlt.sanitytestsuite.model.SanityTestVector;
+
+import java.util.Map;
+
+import static com.radixdlt.sanitytestsuite.scenario.serialization.SerializationTestVector.Expected;
+import static com.radixdlt.sanitytestsuite.scenario.serialization.SerializationTestVector.Input;
+
+// CHECKSTYLE:OFF checkstyle:VisibilityModifier
+public final class SerializationTestVector extends SanityTestVector<Input, Expected> {
+	public static final class Expected {
+		public String jsonPrettyPrinted;
+		public Map<String, Object> dson;
+	}
+
+	public static final class Input {
+		public Map<String, Object> arguments;
+		public String typeSerialization;
+	}
+}
+// CHECKSTYLE:ON

--- a/radixdlt-core/radixdlt/src/test/resources/sanity_test_suite.json
+++ b/radixdlt-core/radixdlt/src/test/resources/sanity_test_suite.json
@@ -1,6 +1,6 @@
 {
 	"integrity": {
-		"hashOfSuite": "45648c4ad69554b49ff3df094cbd5652c8cc9c284413789df4b8759c91e312c4",
+		"hashOfSuite": "20478e94216232bf1822ce42c2302f8ca04e3ffdf3321647d1283275579e6bad",
 		"implementationInfo": "Read the 'suite' object from the root of this file, and prettify it to a JSON string with recursive sorting on keys and with 4 spaces indentation, then UTF8 encode the JSON string and SHA256 has it. Compare the hex of the hash with 'hashOfSuite'."
 	},
 	"suite": {
@@ -364,13 +364,13 @@
 			},
 			{
 				"description": {
-					"implementationInfo": "Each test vector contains a list of key values representing the contents of a Radix model, for which will try to instantiate it. We will then serialize the model into JSON and do a verbatim string comparison against an expected JSON string.",
-					"purpose": "Verify that all Radix models properly serializes into the expected JSON.",
+					"implementationInfo": "edit this -> Each test vector contains a list of key values representing the contents of a Radix model, for which will try to instantiate it. We will then serialize the model into JSON and do a verbatim string comparison against an expected JSON string.",
+					"purpose": "Verify that all Radix models properly serializes into the expected JSON and DSON.",
 					"troubleshooting": "Please bear in mind the Radix JSON value prefixes e.g. ':byt:' prefix prepended to a byte string or ':adr:' prepended to a Radix address."
-			
+
 				},
-				"identifier": "json_serialization_radix_models",
-				"name": "JSON serialization of Radix Models",
+				"identifier": "serialization_radix_models",
+				"name": "JSON and DSON serialization of Radix Models",
 				"tests": {
 					"source": {
 						"comment": "Radix employee named 'Alexander Cyon' made the first implementation of this."
@@ -378,34 +378,24 @@
 					"vectors": [
 						{
 							"expected": {
-								"jsonPrettyPrinted": "{\n  \"address\": \":adr:JEtKBRFrEbZUnY7zrtHsF7aU9eYvL74VyVukp5m5HsKogmWUW1h\",\n  \"amount\": \":u20:960000000000000000\",\n  \"destinations\": [\n    \":uid:e45e72925767ee14d7368fec2a141768\"\n  ],\n  \"granularity\": \":u20:1\",\n  \"nonce\": 12345678,\n  \"permissions\": {\n    \"burn\": \":str:all\",\n    \"mint\": \":str:token_owner_only\"\n  },\n  \"serializer\": \"radix.particles.transferrable_tokens\",\n  \"tokenDefinitionReference\": \":rri:/JH3BuQw985MrbEdrNvW9ixG7evay2rgAhVTppaUkvayJ2r1WszP/XRD\",\n  \"version\": 100\n}"
+								"jsonPrettyPrinted": "{\n  \"address\": \":adr:23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x\",\n  \"amount\": \":u20:8\",\n  \"granularity\": \":u20:1\",\n  \"nonce\": 10550563423900,\n  \"permissions\": {\n    \"burn\": \":str:all\",\n    \"mint\": \":str:token_owner_only\"\n  },\n  \"serializer\": \"radix.particles.transferrable_tokens\",\n  \"tokenDefinitionReference\": \":rri:/23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x/COOKIE\"\n}",
+								"dson": {
+									"allOutputHex": "bf67616464726573735827040703703967d20e7e193380218961d27c450a850ae005182bf76413d2656009c6dc0daf892dc166616d6f756e7458210500000000000000000000000000000000000000000000000000000000000000086c64657374696e6174696f6e7381510220bf3f95bb01b8bbb080401d8ad5baee6b6772616e756c61726974795821050000000000000000000000000000000000000000000000000000000000000001656e6f6e63651b000017c8bc9de6d46b7065726d697373696f6e73bf646275726e63616c6c646d696e7470746f6b656e5f6f776e65725f6f6e6c79ff6a73657269616c697a6572782472616469782e7061727469636c65732e7472616e736665727261626c655f746f6b656e737818746f6b656e446566696e6974696f6e5265666572656e6365583d062f3233423666483346656b4a65503665356775685a416b366e397a34666d546f35546e676f336131315767355238677357545632782f434f4f4b49456776657273696f6e1864ff",
+									"hashOutputHex": "bf67616464726573735827040703703967d20e7e193380218961d27c450a850ae005182bf76413d2656009c6dc0daf892dc166616d6f756e7458210500000000000000000000000000000000000000000000000000000000000000086c64657374696e6174696f6e7381510220bf3f95bb01b8bbb080401d8ad5baee6b6772616e756c61726974795821050000000000000000000000000000000000000000000000000000000000000001656e6f6e63651b000017c8bc9de6d46b7065726d697373696f6e73bf646275726e63616c6c646d696e7470746f6b656e5f6f776e65725f6f6e6c79ff6a73657269616c697a6572782472616469782e7061727469636c65732e7472616e736665727261626c655f746f6b656e737818746f6b656e446566696e6974696f6e5265666572656e6365583d062f3233423666483346656b4a65503665356775685a416b366e397a34666d546f35546e676f336131315767355238677357545632782f434f4f4b49456776657273696f6e1864ff"
+								}
 							},
 							"input": {
 								"typeSerialization": "radix.particles.transferrable_tokens",
 								"arguments": {
-									"address": "JEtKBRFrEbZUnY7zrtHsF7aU9eYvL74VyVukp5m5HsKogmWUW1h",
-									"amount": "960000000000000000",
+									"address": "23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x",
+									"amount": "8",
 									"granularity": "1",
-									"tokenDefinitionReference": "/JH3BuQw985MrbEdrNvW9ixG7evay2rgAhVTppaUkvayJ2r1WszP/XRD",
-									"nonce": "12345678",
+									"tokenDefinitionReference": "/23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x/COOKIE",
+									"nonce": "26150925362900",
 									"tokenPermissions": {
 										"mint": "token_owner_only",
 										"burn": "all"
 									}
-								}
-							}
-						}, 
-						{
-							"expected": {
-								"jsonPrettyPrinted": "{\n  \"bytes\": \":byt:SGVsbG8gQm9iLCB0aGlzIGlzIHlvdXIgZnJpZW5kIEFsaWNlLg==\",\n  \"destinations\": [\n    \":uid:e45e72925767ee14d7368fec2a141768\",\n    \":uid:dfd7c486570a7ad40eb948c80cb89376\"\n  ],\n  \"from\": \":adr:JEtKBRFrEbZUnY7zrtHsF7aU9eYvL74VyVukp5m5HsKogmWUW1h\",\n  \"nonce\": 156115453148799,\n  \"serializer\": \"radix.particles.message\",\n  \"to\": \":adr:JFLKeSQmBZ73YkzWiesdEr2fRT14qCB1DQUvj8KxYQC6m8UTCcF\",\n  \"version\": 100\n}"
-							},
-							"input": {
-								"typeSerialization": "radix.particles.message",
-								"arguments": {
-									"message": "Hello Bob, this is your friend Alice.",
-									"from": "JEtKBRFrEbZUnY7zrtHsF7aU9eYvL74VyVukp5m5HsKogmWUW1h",
-									"to": "JFLKeSQmBZ73YkzWiesdEr2fRT14qCB1DQUvj8KxYQC6m8UTCcF",
-									"nonce": "156115453148799"
 								}
 							}
 						}
@@ -414,13 +404,12 @@
 			},
 			{
 				"description": {
-					"implementationInfo": "Each test vector contains a list of key values representing the contents of a Radix model, for which will try to instantiate a Particle. We will then serialize the particle into JSON and do a verbatim string comparison against an expected JSON string.",
-					"purpose": "Verify that all Radix models properly deserializes from JSON.",
+					"implementationInfo": "edit this -> Each test vector contains a list of key values representing the contents of a Radix model, for which will try to instantiate a Particle. We will then serialize the particle into JSON and do a verbatim string comparison against an expected JSON string.",
+					"purpose": "Verify that all Radix models properly deserializes from JSON and DSON.",
 					"troubleshooting": "Please bear in mind the Radix JSON value prefixes e.g. ':byt:' prefix prepended to a byte string or ':adr:' prepended to a Radix address."
-
 				},
-				"identifier": "json_deserialization_radix_models",
-				"name": "JSON deserialization of Radix Models",
+				"identifier": "deserialization_radix_models",
+				"name": "JSON and DSON deserialization of Radix Models",
 				"tests": {
 					"source": {
 						"comment": "Radix employee named 'Alexander Cyon' made the first implementation of this."
@@ -429,59 +418,64 @@
 						{
 							"expected": {
 								"arguments": {
-									"address": "JEtKBRFrEbZUnY7zrtHsF7aU9eYvL74VyVukp5m5HsKogmWUW1h",
-									"amount": "960000000000000000",
+									"address": "23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x",
+									"amount": "8",
 									"granularity": "1",
-									"tokenDefinitionReference": "/JH3BuQw985MrbEdrNvW9ixG7evay2rgAhVTppaUkvayJ2r1WszP/XRD",
-									"nonce": "12345678",
+									"tokenDefinitionReference": "/23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x/COOKIE",
+									"nonce": "10550563423900",
 									"tokenPermissions": {
-										"mint": "token_owner_only",
-										"burn": "all"
+										"burn": "all",
+										"mint": "token_owner_only"
 									}
 								}
 							},
 							"input": {
 								"typeSerialization": "radix.particles.transferrable_tokens",
-								"json": {
-									"address": ":adr:JEtKBRFrEbZUnY7zrtHsF7aU9eYvL74VyVukp5m5HsKogmWUW1h",
-									"amount": ":u20:960000000000000000",
-									"destinations": [
-										":uid:e45e72925767ee14d7368fec2a141768"
-									],
+								"json":  {
+									"amount": ":u20:8",
+									"address": ":adr:23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x",
 									"granularity": ":u20:1",
-									"nonce": 12345678,
 									"permissions": {
 										"burn": ":str:all",
 										"mint": ":str:token_owner_only"
 									},
 									"serializer": "radix.particles.transferrable_tokens",
-									"tokenDefinitionReference": ":rri:/JH3BuQw985MrbEdrNvW9ixG7evay2rgAhVTppaUkvayJ2r1WszP/XRD",
-									"version": 100
+									"nonce": 10550563423900,
+									"tokenDefinitionReference": ":rri:/23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x/COOKIE"
+								},
+								"dson": {
+									"allOutputHex": "bf67616464726573735827040703703967d20e7e193380218961d27c450a850ae005182bf76413d2656009c6dc0daf892dc166616d6f756e7458210500000000000000000000000000000000000000000000000000000000000000086b6772616e756c61726974795821050000000000000000000000000000000000000000000000000000000000000001656e6f6e63651b000009987e95c69c6b7065726d697373696f6e73bf646275726e63616c6c646d696e7470746f6b656e5f6f776e65725f6f6e6c79ff6a73657269616c697a6572782472616469782e7061727469636c65732e7472616e736665727261626c655f746f6b656e737818746f6b656e446566696e6974696f6e5265666572656e6365583d062f3233423666483346656b4a65503665356775685a416b366e397a34666d546f35546e676f336131315767355238677357545632782f434f4f4b4945ff",
+									"hashOutputHex": "bf67616464726573735827040703703967d20e7e193380218961d27c450a850ae005182bf76413d2656009c6dc0daf892dc166616d6f756e7458210500000000000000000000000000000000000000000000000000000000000000086b6772616e756c61726974795821050000000000000000000000000000000000000000000000000000000000000001656e6f6e63651b000009987e95c69c6b7065726d697373696f6e73bf646275726e63616c6c646d696e7470746f6b656e5f6f776e65725f6f6e6c79ff6a73657269616c697a6572782472616469782e7061727469636c65732e7472616e736665727261626c655f746f6b656e737818746f6b656e446566696e6974696f6e5265666572656e6365583d062f3233423666483346656b4a65503665356775685a416b366e397a34666d546f35546e676f336131315767355238677357545632782f434f4f4b4945ff"
 								}
 							}
 						},
 						{
 							"expected": {
-								"arguments": {
-									"message": "Hello Bob, this is your friend Alice.",
-									"from": "JEtKBRFrEbZUnY7zrtHsF7aU9eYvL74VyVukp5m5HsKogmWUW1h",
-									"to": "JFLKeSQmBZ73YkzWiesdEr2fRT14qCB1DQUvj8KxYQC6m8UTCcF",
-									"nonce": "156115453148799"
+								"arguments":  {
+									"granularity": "1",
+									"rri": "/23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x/COOKIE",
+									"name": "TEST",
+									"description": "description",
+									"iconUrl": "http://somewhere.com/icon.jpg",
+									"supply": "10",
+									"url": "http://somewhere.com"
 								}
 							},
 							"input": {
-								"typeSerialization": "radix.particles.message",
-								"json": {
-									"bytes": ":byt:SGVsbG8gQm9iLCB0aGlzIGlzIHlvdXIgZnJpZW5kIEFsaWNlLg==",
-									"destinations": [
-										":uid:e45e72925767ee14d7368fec2a141768",
-										":uid:dfd7c486570a7ad40eb948c80cb89376"
-									],
-									"from": ":adr:JEtKBRFrEbZUnY7zrtHsF7aU9eYvL74VyVukp5m5HsKogmWUW1h",
-									"nonce": 156115453148799,
-									"serializer": "radix.particles.message",
-									"to": ":adr:JFLKeSQmBZ73YkzWiesdEr2fRT14qCB1DQUvj8KxYQC6m8UTCcF",
-									"version": 100
+								"typeSerialization": "radix.particles.fixed_supply_token_definition",
+								"json":   {
+									"granularity": ":u20:1",
+									"rri": ":rri:/23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x/COOKIE",
+									"name": ":str:TEST",
+									"serializer": "radix.particles.fixed_supply_token_definition",
+									"description": ":str:description",
+									"iconUrl": ":str:http://somewhere.com/icon.jpg",
+									"supply": ":u20:10",
+									"url": ":str:http://somewhere.com"
+								},
+								"dson": {
+									"allOutputHex": "bf6b6465736372697074696f6e6b6465736372697074696f6e6b6772616e756c617269747958210500000000000000000000000000000000000000000000000000000000000000016769636f6e55726c781d687474703a2f2f736f6d6577686572652e636f6d2f69636f6e2e6a7067646e616d65645445535463727269583d062f3233423666483346656b4a65503665356775685a416b366e397a34666d546f35546e676f336131315767355238677357545632782f434f4f4b49456a73657269616c697a6572782d72616469782e7061727469636c65732e66697865645f737570706c795f746f6b656e5f646566696e6974696f6e66737570706c79582105000000000000000000000000000000000000000000000000000000000000000a6375726c74687474703a2f2f736f6d6577686572652e636f6dff",
+									"hashOutputHex": "bf6b6465736372697074696f6e6b6465736372697074696f6e6b6772616e756c617269747958210500000000000000000000000000000000000000000000000000000000000000016769636f6e55726c781d687474703a2f2f736f6d6577686572652e636f6d2f69636f6e2e6a7067646e616d65645445535463727269583d062f3233423666483346656b4a65503665356775685a416b366e397a34666d546f35546e676f336131315767355238677357545632782f434f4f4b49456a73657269616c697a6572782d72616469782e7061727469636c65732e66697865645f737570706c795f746f6b656e5f646566696e6974696f6e66737570706c79582105000000000000000000000000000000000000000000000000000000000000000a6375726c74687474703a2f2f736f6d6577686572652e636f6dff"
 								}
 							}
 						}

--- a/radixdlt-engine/src/test/java/com/radixdlt/JsonAndDsonPrinter.java
+++ b/radixdlt-engine/src/test/java/com/radixdlt/JsonAndDsonPrinter.java
@@ -1,0 +1,162 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.radixdlt.atommodel.system.SystemParticle;
+import com.radixdlt.atommodel.tokens.*;
+import com.radixdlt.atommodel.validators.RegisteredValidatorParticle;
+import com.radixdlt.atommodel.validators.UnregisteredValidatorParticle;
+import com.radixdlt.atomos.RRIParticle;
+import com.radixdlt.constraintmachine.Particle;
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+import com.radixdlt.serialization.DsonOutput;
+import com.radixdlt.serialization.Serialization;
+import com.radixdlt.utils.Bytes;
+import com.radixdlt.utils.UInt256;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class JsonAndDsonPrinter {
+
+    private static final Logger logger = LogManager.getLogger();
+    public static final RadixAddress ADDRESS = RadixAddress.from("23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x");
+    public static final RadixAddress ADDRESS2 = RadixAddress.from("JEbhKQzBn4qJzWJFBbaPioA2GTeaQhuUjYWkanTE6N8VvvPpvM8");
+    public static final RadixAddress ADDRESS3 = RadixAddress.from("JHJTc1vUVA3JbjKCDtNu3x7tPaeB8fFcfnYp26s3hzos3s351To");
+    public static final RRI TOKEN_RRI = RRI.of(ADDRESS, "COOKIE");
+    public static final ImmutableMap<MutableSupplyTokenDefinitionParticle.TokenTransition, TokenPermission> TOKEN_PERMISSIONS = ImmutableMap.of(
+            MutableSupplyTokenDefinitionParticle.TokenTransition.BURN, TokenPermission.ALL,
+            MutableSupplyTokenDefinitionParticle.TokenTransition.MINT, TokenPermission.TOKEN_OWNER_ONLY
+    );
+
+    private Serialization instance = DefaultSerialization.getInstance();
+
+    @Test
+    public void logAllParticles() {
+        logFixedSupplyTokenDefinitionParticle();
+        logMutableSupplyTokenDefinitionParticle();
+        logStakedTokensParticle();
+        logTransferableTokensParticle();
+        logUnallocatedTokensParticle();
+        logRRIParticle();
+        logRegisteredValidatorParticle();
+        logUnregisteredValidatorParticle();
+        logSystemParticle();
+    }
+
+    private void logSystemParticle() {
+        final var particle = new SystemParticle(1, 1000, System.currentTimeMillis());
+        logParticle(particle);
+    }
+
+    private void logUnregisteredValidatorParticle() {
+        final var particle = new UnregisteredValidatorParticle(
+                ADDRESS,
+                1L);
+        logParticle(particle);
+    }
+
+    private void logRegisteredValidatorParticle() {
+        final var particle = new RegisteredValidatorParticle(
+                ADDRESS,
+                ImmutableSet.of(ADDRESS2, ADDRESS3),
+                1L);
+        logParticle(particle);
+    }
+
+    private void logRRIParticle() {
+        final var particle = new RRIParticle(TOKEN_RRI);
+        logParticle(particle);
+    }
+
+    private void logUnallocatedTokensParticle() {
+        final var particle = new UnallocatedTokensParticle(
+                UInt256.TEN,
+                UInt256.ONE,
+                TOKEN_RRI,
+                TOKEN_PERMISSIONS
+        );
+        logParticle(particle);
+    }
+
+    private void logTransferableTokensParticle() {
+        final var particle = new TransferrableTokensParticle(
+                ADDRESS,
+                UInt256.EIGHT,
+                UInt256.ONE,
+                TOKEN_RRI,
+                TOKEN_PERMISSIONS
+        );
+        logParticle(particle);
+    }
+
+    private void logStakedTokensParticle() {
+        final var particle = new StakedTokensParticle(
+                ADDRESS,
+                ADDRESS,
+                UInt256.EIGHT,
+                UInt256.ONE,
+                TOKEN_RRI,
+                TOKEN_PERMISSIONS
+        );
+        logParticle(particle);
+    }
+
+    private void logMutableSupplyTokenDefinitionParticle() {
+        final var particle = new MutableSupplyTokenDefinitionParticle(
+                TOKEN_RRI,
+                "TEST",
+                "description",
+                UInt256.ONE,
+                "http://somewhere.com/icon.jpg",
+                "http://somewhere.com",
+                TOKEN_PERMISSIONS
+        );
+        logParticle(particle);
+    }
+
+    private void logFixedSupplyTokenDefinitionParticle() {
+        final var particle = new FixedSupplyTokenDefinitionParticle(
+                TOKEN_RRI,
+                "TEST",
+                "description",
+                UInt256.TEN,
+                UInt256.ONE,
+                "http://somewhere.com/icon.jpg",
+                "http://somewhere.com"
+        );
+        logParticle(particle);
+    }
+
+    private void logParticle(Particle particle) {
+        System.out.println();
+        logger.info("=".repeat(20) + particle.getClass().getName() + "=".repeat(20));
+        String json = instance.toJson(particle, DsonOutput.Output.ALL);
+        logger.info("JSON:\n {}", new JSONObject(json).toString(5));
+        byte[] bytesAll = instance.toDson(particle, DsonOutput.Output.ALL);
+        byte[] bytesHash = instance.toDson(particle, DsonOutput.Output.HASH);
+        logger.info("Hex of Output.ALL: {}", Bytes.toHexString(bytesAll));
+        logger.info("Hex of Output.HASH: {}", Bytes.toHexString(bytesHash));
+        logger.info("=".repeat(50));
+    }
+
+}


### PR DESCRIPTION
So instead of having 4 different scenarios (json serialization, json deserialization, dson serialization and dson deserialization) which need much boilerplate, we could have 2:

- DeserializationTestScenarioRunner, which
1. Deserializes the JSON to particle1
2. Asserts that particle1 has the expected properties
3. Deserializes the DSON to particle2
4. Asserts that particle1 equals() particle2

- SerializationTestScenarioRunner, which
1. Serializes a given particle to JSON
2. Asserts that the JSON is as expected
3. Serializes the particle to DSON 
4. Asserts that the DSON is as expected

These tests basically test both JSON and DSON (in hex) in one go. Right now I only test for 2 particle types, but adding the other 7 is easy.

I am also not sure if it makes sense to check both `DsonOutput.Output.ALL` and `DsonOutput.Output.HASH`.

I get my data from the JsonAndDsonPrinter helper class. I will probably delete it before merging to rc.