### PR TITLE
Bugfix/hide leaked abstractions

### DIFF
--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/distributed/MockedPersistenceStoreModule.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/distributed/MockedPersistenceStoreModule.java
@@ -24,6 +24,8 @@ import com.radixdlt.consensus.safety.PersistentSafetyStateStore;
 import com.radixdlt.consensus.safety.SafetyState;
 import com.radixdlt.store.Transaction;
 
+import java.util.Optional;
+
 public class MockedPersistenceStoreModule extends AbstractModule {
 
 	@Override
@@ -34,6 +36,11 @@ public class MockedPersistenceStoreModule extends AbstractModule {
 
 	private static class MockedPersistenceStore implements PersistentSafetyStateStore {
 		@Override
+		public Optional<SafetyState> get() {
+			return Optional.empty();
+		}
+
+		@Override
 		public void commitState(SafetyState safetyState) {
 			// Nothing to do here
 		}
@@ -42,7 +49,6 @@ public class MockedPersistenceStoreModule extends AbstractModule {
 		public void close() {
 			// Nothing to do here
 		}
-
 	}
 
 	private static class MockedPersistentVertexStore implements PersistentVertexStore {

--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/recovery/OneNodeAlwaysAliveSafetyTest.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/recovery/OneNodeAlwaysAliveSafetyTest.java
@@ -51,7 +51,7 @@ import com.radixdlt.integration.distributed.deterministic.SafetyCheckerModule;
 import com.radixdlt.properties.RuntimeProperties;
 import com.radixdlt.recovery.ModuleForRecoveryTests;
 import com.radixdlt.statecomputer.EpochCeilingView;
-import com.radixdlt.store.berkeley.BerkeleyLedgerEntryStore;
+import com.radixdlt.store.LedgerEntryStore;
 import com.radixdlt.sync.LocalSyncRequest;
 import io.reactivex.rxjava3.schedulers.Timed;
 import java.util.ArrayList;
@@ -153,7 +153,7 @@ public class OneNodeAlwaysAliveSafetyTest {
 	}
 
 	private void stopDatabase(Injector injector) {
-		injector.getInstance(BerkeleyLedgerEntryStore.class).close();
+		injector.getInstance(LedgerEntryStore.class).close();
 		injector.getInstance(PersistentSafetyStateStore.class).close();
 		injector.getInstance(DatabaseEnvironment.class).stop();
 	}

--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/recovery/RecoveryLivenessTest.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/recovery/RecoveryLivenessTest.java
@@ -53,8 +53,8 @@ import com.radixdlt.middleware2.network.GetVerticesRequestRateLimit;
 import com.radixdlt.properties.RuntimeProperties;
 import com.radixdlt.recovery.ModuleForRecoveryTests;
 import com.radixdlt.statecomputer.EpochCeilingView;
-import com.radixdlt.store.berkeley.BerkeleyLedgerEntryStore;
 
+import com.radixdlt.store.LedgerEntryStore;
 import io.reactivex.rxjava3.schedulers.Timed;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -153,7 +153,7 @@ public class RecoveryLivenessTest {
 	}
 
 	private void stopDatabase(Injector injector) {
-		injector.getInstance(BerkeleyLedgerEntryStore.class).close();
+		injector.getInstance(LedgerEntryStore.class).close();
 		injector.getInstance(PersistentSafetyStateStore.class).close();
 		injector.getInstance(DatabaseEnvironment.class).stop();
 	}

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/ConsensusRecoveryModule.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/ConsensusRecoveryModule.java
@@ -31,9 +31,9 @@ import com.radixdlt.consensus.bft.View;
 import com.radixdlt.consensus.bft.ViewUpdate;
 import com.radixdlt.consensus.epoch.EpochChange;
 import com.radixdlt.consensus.liveness.ProposerElection;
+import com.radixdlt.consensus.safety.PersistentSafetyStateStore;
 import com.radixdlt.consensus.safety.SafetyState;
 import com.radixdlt.store.LastEpochProof;
-import com.radixdlt.store.berkeley.BerkeleySafetyStateStore;
 import java.util.Optional;
 
 /**
@@ -71,8 +71,8 @@ public class ConsensusRecoveryModule extends AbstractModule {
 
 	@Provides
 	@Singleton
-	private SafetyState safetyState(EpochChange initialEpoch, BerkeleySafetyStateStore berkeleySafetyStore) {
-		return berkeleySafetyStore.get().flatMap(safetyState -> {
+	private SafetyState safetyState(EpochChange initialEpoch, PersistentSafetyStateStore safetyStore) {
+		return safetyStore.get().flatMap(safetyState -> {
 			final long safetyStateEpoch =
 				safetyState.getLastVote().map(Vote::getEpoch).orElse(0L);
 

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/LedgerRecoveryModule.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/LedgerRecoveryModule.java
@@ -35,7 +35,7 @@ import com.radixdlt.ledger.VerifiedCommandsAndProof;
 import com.radixdlt.middleware2.store.CommittedAtomsStore;
 import com.radixdlt.store.LastEpochProof;
 import com.radixdlt.store.LastProof;
-import com.radixdlt.store.berkeley.BerkeleyLedgerEntryStore;
+import com.radixdlt.store.LedgerEntryStore;
 
 import java.util.Optional;
 
@@ -81,10 +81,10 @@ public final class LedgerRecoveryModule extends AbstractModule {
 	@Singleton
 	private VerifiedVertexStoreState vertexStoreState(
 		@LastEpochProof VerifiedLedgerHeaderAndProof lastEpochProof,
-		BerkeleyLedgerEntryStore berkeleyLedgerEntryStore,
+		LedgerEntryStore ledgerEntryStore,
 		Hasher hasher
 	) {
-		return berkeleyLedgerEntryStore.loadLastVertexStoreState()
+		return ledgerEntryStore.loadLastVertexStoreState()
 				.map(serializedVertexStoreState -> {
 					UnverifiedVertex root = serializedVertexStoreState.getRoot();
 					HashCode rootVertexId = hasher.hash(root);

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/safety/PersistentSafetyStateStore.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/safety/PersistentSafetyStateStore.java
@@ -17,10 +17,13 @@
 
 package com.radixdlt.consensus.safety;
 
+import java.util.Optional;
+
 /**
  * Responsible for synchronously persisting safety state
  */
 public interface PersistentSafetyStateStore {
 	void commitState(SafetyState safetyState);
 	void close();
+	Optional<SafetyState> get();
 }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/addressbook/AddressBookModule.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/addressbook/AddressBookModule.java
@@ -19,6 +19,7 @@ package com.radixdlt.network.addressbook;
 
 import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.properties.RuntimeProperties;
+import com.radixdlt.store.berkeley.BerkeleyAddressBookPersistence;
 import org.radix.database.DatabaseEnvironment;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -44,7 +45,7 @@ public final class AddressBookModule extends AbstractModule {
 	@Provides
 	@Singleton
 	PeerPersistence addressBookPersistenceProvider(Serialization serialization, DatabaseEnvironment dbEnv, SystemCounters systemCounters) {
-		AddressBookPersistence persistence = new AddressBookPersistence(serialization, dbEnv, systemCounters);
+		var persistence = new BerkeleyAddressBookPersistence(serialization, dbEnv, systemCounters);
 		persistence.start();
 		return persistence;
 	}

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/addressbook/PeerPersistence.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/addressbook/PeerPersistence.java
@@ -25,7 +25,17 @@ import com.radixdlt.identifiers.EUID;
 /**
  * Persistence interface for persisting peers in AddressBook.
  */
-public interface PeerPersistence extends Closeable  {
+public interface PeerPersistence extends Closeable {
+
+	/**
+	 * Starts persistence.
+	 */
+	void start();
+
+	/**
+	 * Clears content of the underlying store.
+	 */
+	void reset();
 
 	/**
 	 * Saves peer to database.
@@ -49,4 +59,9 @@ public interface PeerPersistence extends Closeable  {
 	 * @param c the consumer to call with each persisted peer
 	 */
 	void forEachPersistedPeer(Consumer<PeerWithSystem> c);
+
+	/**
+	 * Closes persistence
+	 */
+	void close();
 }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/store/LedgerEntryStore.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/store/LedgerEntryStore.java
@@ -18,7 +18,9 @@
 package com.radixdlt.store;
 
 import com.radixdlt.identifiers.AID;
+import com.radixdlt.store.berkeley.SerializedVertexStoreState;
 
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -43,4 +45,6 @@ public interface LedgerEntryStore extends LedgerEntryStoreView {
 	void reset();
 
 	void close();
+
+	Optional<SerializedVertexStoreState> loadLastVertexStoreState();
 }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/store/berkeley/BerkeleyLedgerEntryStore.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/store/berkeley/BerkeleyLedgerEntryStore.java
@@ -316,6 +316,7 @@ public class BerkeleyLedgerEntryStore implements LedgerEntryStore, PersistentVer
 		}
 	}
 
+	@Override
 	public Optional<SerializedVertexStoreState> loadLastVertexStoreState() {
 		final var start = System.nanoTime();
 		try {

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/store/berkeley/BerkeleySafetyStateStore.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/store/berkeley/BerkeleySafetyStateStore.java
@@ -24,10 +24,12 @@ import com.radixdlt.consensus.safety.PersistentSafetyStateStore;
 import com.radixdlt.consensus.safety.SafetyState;
 import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.counters.SystemCounters.CounterType;
+import com.radixdlt.network.addressbook.PeerWithSystem;
 import com.radixdlt.serialization.DeserializeException;
 import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.serialization.Serialization;
 import com.radixdlt.utils.Longs;
+import com.sleepycat.je.Cursor;
 import com.sleepycat.je.Database;
 import com.sleepycat.je.DatabaseConfig;
 import com.sleepycat.je.DatabaseEntry;
@@ -35,27 +37,32 @@ import com.sleepycat.je.Environment;
 import com.sleepycat.je.LockMode;
 import com.sleepycat.je.OperationStatus;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.radix.database.DatabaseEnvironment;
 
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Store which persists state required to preserve the networks safety in case of a
  * node restart.
- *
- * TODO: Prune saved safety state.
  */
 public final class BerkeleySafetyStateStore implements PersistentSafetyStateStore {
 	private static final String SAFETY_STORE_NAME = "safety_store";
 	private static final Logger logger = LogManager.getLogger();
+	private static final long UPPER_THRESHOLD = 1000;
+	private static final long LOWER_THRESHOLD = 10;
 
 	private final DatabaseEnvironment dbEnv;
 	private final Database safetyStore;
 	private final SystemCounters systemCounters;
-	private Serialization serialization;
+	private final AtomicLong cleanupCounter = new AtomicLong();
+	private final Serialization serialization;
 
 	@Inject
 	public BerkeleySafetyStateStore(
@@ -107,6 +114,7 @@ public final class BerkeleySafetyStateStore implements PersistentSafetyStateStor
 		}
 	}
 
+	@Override
 	public Optional<SafetyState> get() {
 		final var start = System.nanoTime();
 		try (com.sleepycat.je.Cursor cursor = this.safetyStore.openCursor(null, null)) {
@@ -131,8 +139,6 @@ public final class BerkeleySafetyStateStore implements PersistentSafetyStateStor
 		}
 	}
 
-
-
 	@Override
 	public void commitState(SafetyState safetyState) {
 		this.systemCounters.increment(CounterType.PERSISTENCE_SAFETY_STORE_SAVES);
@@ -154,11 +160,57 @@ public final class BerkeleySafetyStateStore implements PersistentSafetyStateStor
 			}
 
 			transaction.commit();
+
+			cleanupUnused();
 		} catch (Exception e) {
 			transaction.abort();
 			fail("Error while storing safety state for " + safetyState, e);
 		} finally {
 			addTime(start);
+		}
+	}
+
+	private void cleanupUnused() {
+		if (cleanupCounter.incrementAndGet() % UPPER_THRESHOLD != 0) {
+			return;
+		}
+
+		final var transaction = dbEnv.getEnvironment().beginTransaction(null, null);
+		try {
+			long count = safetyStore.count();
+
+			if (count < UPPER_THRESHOLD) {
+				transaction.abort();
+				return;
+			}
+
+			try (Cursor cursor = this.safetyStore.openCursor(null, null)) {
+				DatabaseEntry key = new DatabaseEntry();
+				DatabaseEntry value = new DatabaseEntry();
+
+				if (cursor.getFirst(key, value, LockMode.DEFAULT) == OperationStatus.SUCCESS) {
+					if (cursor.delete() != OperationStatus.SUCCESS) {
+						transaction.abort();
+						return;
+					}
+					addBytesRead(key.getSize() + value.getSize());
+					count--;
+				}
+
+				while (cursor.getNext(key, value, LockMode.DEFAULT) == OperationStatus.SUCCESS && count > LOWER_THRESHOLD) {
+					if (cursor.delete() != OperationStatus.SUCCESS) {
+						transaction.abort();
+						return;
+					}
+					addBytesRead(key.getSize() + value.getSize());
+					count--;
+				}
+			}
+
+			transaction.commit();
+		} catch (Exception e) {
+			transaction.abort();
+			fail("Error while clearing unused states", e);
 		}
 	}
 

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/store/berkeley/BerkeleySafetyStateStore.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/store/berkeley/BerkeleySafetyStateStore.java
@@ -24,7 +24,6 @@ import com.radixdlt.consensus.safety.PersistentSafetyStateStore;
 import com.radixdlt.consensus.safety.SafetyState;
 import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.counters.SystemCounters.CounterType;
-import com.radixdlt.network.addressbook.PeerWithSystem;
 import com.radixdlt.serialization.DeserializeException;
 import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.serialization.Serialization;
@@ -37,15 +36,12 @@ import com.sleepycat.je.Environment;
 import com.sleepycat.je.LockMode;
 import com.sleepycat.je.OperationStatus;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.radix.database.DatabaseEnvironment;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -184,7 +180,7 @@ public final class BerkeleySafetyStateStore implements PersistentSafetyStateStor
 				return;
 			}
 
-			try (Cursor cursor = this.safetyStore.openCursor(null, null)) {
+			try (Cursor cursor = this.safetyStore.openCursor(transaction, null)) {
 				DatabaseEntry key = new DatabaseEntry();
 				DatabaseEntry value = new DatabaseEntry();
 

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/store/berkeley/BerkeleyAddressBookPersistenceTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/store/berkeley/BerkeleyAddressBookPersistenceTest.java
@@ -15,11 +15,14 @@
  * language governing permissions and limitations under the License.
  */
 
-package com.radixdlt.network.addressbook;
+package com.radixdlt.store.berkeley;
 
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
-
+import com.google.common.collect.ImmutableList;
+import com.radixdlt.counters.SystemCounters;
+import com.radixdlt.crypto.ECKeyPair;
+import com.radixdlt.network.addressbook.Peer;
+import com.radixdlt.network.addressbook.PeerPersistence;
+import com.radixdlt.network.addressbook.PeerWithSystem;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,22 +34,25 @@ import org.radix.time.Time;
 import org.radix.time.Timestamps;
 import org.radix.universe.system.RadixSystem;
 
-import com.google.common.collect.ImmutableList;
-import com.radixdlt.counters.SystemCounters;
-import com.radixdlt.crypto.ECKeyPair;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class AddressBookPersistenceTest extends RadixTest {
+public class BerkeleyAddressBookPersistenceTest extends RadixTest {
 
-	private AddressBookPersistence abp;
+	private PeerPersistence abp;
 	private DatabaseEnvironment dbEnv;
 
 	@Before
 	public void setUp() {
 		this.dbEnv = new DatabaseEnvironment(getProperties());
-		this.abp = new AddressBookPersistence(getSerialization(), dbEnv, mock(SystemCounters.class));
+		this.abp = new BerkeleyAddressBookPersistence(getSerialization(), dbEnv, mock(SystemCounters.class));
 		this.abp.reset();
 	}
 


### PR DESCRIPTION
Cleanups and shuffling persistence-related code to make is more encapsulated and easier to maintain.