### PR TITLE
Chaos testing on testnets

### DIFF
--- a/radixdlt-regression/system-tests/build.gradle
+++ b/radixdlt-regression/system-tests/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxjava'
     implementation 'org.json:json'
 
-    //testImplementation 'com.jcraft:jsch:0.1.53'
     testImplementation 'com.github.mwiede:jsch:0.1.61'
     testImplementation 'commons-io:commons-io:2.8.0'
 

--- a/radixdlt-regression/system-tests/build.gradle
+++ b/radixdlt-regression/system-tests/build.gradle
@@ -33,6 +33,10 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxjava'
     implementation 'org.json:json'
 
+    //testImplementation 'com.jcraft:jsch:0.1.53'
+    testImplementation 'com.github.mwiede:jsch:0.1.61'
+    testImplementation 'commons-io:commons-io:2.8.0'
+
     testImplementation 'org.codehaus.groovy:groovy-all:2.4.12'
     testCompile group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.6.1'
     testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.0.3'

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/RemoteBFTNetworkBridge.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/RemoteBFTNetworkBridge.java
@@ -64,7 +64,7 @@ public final class RemoteBFTNetworkBridge {
 	private Single<String> makeRequest(Request request) {
 		final var newRequestId = requestId.incrementAndGet();
 		final var newRequestTime = System.currentTimeMillis();
-		log.info("Request {}: {}", newRequestId, request);
+		log.debug("Request {}: {}", newRequestId, request);
 		return Single.create(emitter -> {
 			Call call = this.client.newCall(request);
 			call.enqueue(new Callback() {
@@ -104,7 +104,7 @@ public final class RemoteBFTNetworkBridge {
 
 	private void logRequestSuccessful(int requestId, long requestTime, String body) {
 		final var requestDuration = System.currentTimeMillis() - requestTime;
-		log.info("Request {} ({}ms): successful {}", requestId, requestDuration, body);
+		log.debug("Request {} ({}ms): successful {}", requestId, requestDuration, body);
 	}
 
 	private void logRequestFailed(int requestId, long requestTime, int code, String body) {

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosTests.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosTests.java
@@ -19,11 +19,15 @@ package com.radixdlt.test.chaos;
 
 import com.radixdlt.test.Cluster;
 import com.radixdlt.test.Conditions;
-import com.radixdlt.test.chaos.actions.*;
+import com.radixdlt.test.chaos.actions.MempoolFillAction;
+import com.radixdlt.test.chaos.actions.NetworkAction;
+import com.radixdlt.test.chaos.actions.ShutdownAction;
+import com.radixdlt.test.chaos.actions.RestartAction;
+import com.radixdlt.test.chaos.actions.ValidatorRegistrationAction;
+import com.radixdlt.test.chaos.actions.Action;
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -38,20 +42,20 @@ public class ChaosTests {
 
     @Test
     public void pre_release_experiment() {
-        //Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
+        Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
 
         Set<Action> actions = Set.of(
                 new NetworkAction(ansible, 0.2),
                 new RestartAction(ansible, 0.7),
                 new ShutdownAction(ansible, 0.1),
-                new MempoolFillAction(ansible, 0.6, 30),
+                new MempoolFillAction(ansible, 0.7, 30),
                 new ValidatorRegistrationAction(ansible, 0.1)
         );
 
         actions.forEach(Action::teardown);
         actions.forEach(Action::setup);
 
-        //Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
+        Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
     }
 
 }

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosTests.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosTests.java
@@ -1,0 +1,57 @@
+/*
+ * (C) Copyright 2021 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.test.chaos;
+
+import com.radixdlt.test.Cluster;
+import com.radixdlt.test.Conditions;
+import com.radixdlt.test.chaos.actions.*;
+import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Set;
+
+@Category(Cluster.class)
+public class ChaosTests {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final AnsibleImageWrapper ansible = AnsibleImageWrapper.createWithDefaultImage();
+
+    @Test
+    public void pre_release_experiment() {
+        //Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
+
+        Set<Action> actions = Set.of(
+                new NetworkAction(ansible, 0.2),
+                new RestartAction(ansible, 0.7),
+                new ShutdownAction(ansible, 0.1),
+                new MempoolFillAction(ansible, 0.6, 30),
+                new ValidatorRegistrationAction(ansible, 0.1)
+        );
+
+        actions.forEach(Action::teardown);
+        actions.forEach(Action::setup);
+
+        //Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
+    }
+
+}

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosTests.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosTests.java
@@ -48,7 +48,7 @@ public class ChaosTests {
                 new NetworkAction(ansible, 0.2),
                 new RestartAction(ansible, 0.7),
                 new ShutdownAction(ansible, 0.1),
-                new MempoolFillAction(ansible, 0.7, 30),
+                new MempoolFillAction(ansible, 0.8, 300),
                 new ValidatorRegistrationAction(ansible, 0.1)
         );
 

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosTests.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosTests.java
@@ -18,13 +18,8 @@
 package com.radixdlt.test.chaos;
 
 import com.radixdlt.test.Cluster;
-import com.radixdlt.test.Conditions;
-import com.radixdlt.test.chaos.actions.MempoolFillAction;
-import com.radixdlt.test.chaos.actions.NetworkAction;
-import com.radixdlt.test.chaos.actions.ShutdownAction;
-import com.radixdlt.test.chaos.actions.RestartAction;
-import com.radixdlt.test.chaos.actions.ValidatorRegistrationAction;
 import com.radixdlt.test.chaos.actions.Action;
+import com.radixdlt.test.chaos.actions.ValidatorRegistrationAction;
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,20 +37,20 @@ public class ChaosTests {
 
     @Test
     public void pre_release_experiment() {
-        Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
+        //Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
 
         Set<Action> actions = Set.of(
-                new NetworkAction(ansible, 0.2),
-                new RestartAction(ansible, 0.7),
-                new ShutdownAction(ansible, 0.1),
-                new MempoolFillAction(ansible, 0.8, 300),
-                new ValidatorRegistrationAction(ansible, 0.1)
+                //new NetworkAction(ansible, 0.4)
+                //new RestartAction(ansible, 0.7),
+                //new ShutdownAction(ansible, 0.1),
+                //new MempoolFillAction(ansible, 0.8, 300)
+                new ValidatorRegistrationAction(ansible, 1.0)
         );
 
         actions.forEach(Action::teardown);
         actions.forEach(Action::setup);
 
-        Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
+        //Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
     }
 
 }

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosTests.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosTests.java
@@ -18,8 +18,13 @@
 package com.radixdlt.test.chaos;
 
 import com.radixdlt.test.Cluster;
+import com.radixdlt.test.Conditions;
 import com.radixdlt.test.chaos.actions.Action;
+import com.radixdlt.test.chaos.actions.NetworkAction;
+import com.radixdlt.test.chaos.actions.RestartAction;
 import com.radixdlt.test.chaos.actions.ValidatorRegistrationAction;
+import com.radixdlt.test.chaos.actions.ShutdownAction;
+import com.radixdlt.test.chaos.actions.MempoolFillAction;
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -37,20 +42,20 @@ public class ChaosTests {
 
     @Test
     public void pre_release_experiment() {
-        //Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
+        Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
 
         Set<Action> actions = Set.of(
-                //new NetworkAction(ansible, 0.4)
-                //new RestartAction(ansible, 0.7),
-                //new ShutdownAction(ansible, 0.1),
-                //new MempoolFillAction(ansible, 0.8, 300)
-                new ValidatorRegistrationAction(ansible, 1.0)
+                new NetworkAction(ansible, 0.4),
+                new RestartAction(ansible, 0.7),
+                new ShutdownAction(ansible, 0.1),
+                new MempoolFillAction(ansible, 0.8, 300),
+                new ValidatorRegistrationAction(ansible, 0.2)
         );
 
         actions.forEach(Action::teardown);
         actions.forEach(Action::setup);
 
-        //Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
+        Conditions.waitUntilNetworkHasLiveness(ansible.toNetwork());
     }
 
 }

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/HttpClient.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/HttpClient.java
@@ -1,0 +1,108 @@
+package com.radixdlt.test.chaos;
+
+import com.radixdlt.client.core.network.HttpClients;
+import com.radixdlt.test.chaos.actions.ActionFailedException;
+import okhttp3.*;
+import org.json.JSONObject;
+import org.junit.platform.commons.util.StringUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+
+/**
+ * A wrapper around a real httpclient, which provides easy to use methods. Knows the url paths.
+ */
+public class HttpClient {
+
+    private final static String MEMPOOL_FILLER_PATH = "/api/chaos/mempool-filler";
+    private final static String VALIDATOR_REGISTRATION_PATH = "/node/validator";
+
+    private final OkHttpClient okHttpClient;
+    private final String protocol;
+    private final String faucetUrl;
+    private String encodedBasicAuthCredentials;
+
+    public HttpClient() {
+        this(true);
+    }
+
+    public HttpClient(boolean isHttps) {
+        okHttpClient = HttpClients.getSslAllTrustingClient();
+        protocol = isHttps ? "https://" : "http://";
+        String basicAuthCredentials = System.getenv("HTTP_API_BASIC_AUTH");
+        faucetUrl = Optional.ofNullable(System.getenv("FAUCET_URL"))
+                .orElse("https://milestonenet-faucet.radixdlt.com/faucet/api/v1/getTokens/");
+        if (StringUtils.isNotBlank(basicAuthCredentials)) {
+            this.encodedBasicAuthCredentials = Base64.getEncoder()
+                    .encodeToString(basicAuthCredentials.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    public void callFaucetForAddress(String address) {
+        try {
+            Response response = okHttpClient.newCall(new Request.Builder()
+                    .url(faucetUrl + address)
+                    .build()
+            ).execute();
+            if (!response.isSuccessful()) {
+                throw new ActionFailedException("Could not call faucet");
+            }
+        } catch (IOException e) {
+            throw new ActionFailedException(e);
+        }
+    }
+
+    public void unregisterValidator(String host) {
+        makeRequest(host, VALIDATOR_REGISTRATION_PATH, "POST", "{\"enabled\":false}");
+    }
+
+    public void registerValidator(String host) {
+        makeRequest(host, VALIDATOR_REGISTRATION_PATH, "POST", "{\"enabled\":true}");
+    }
+
+    public String getMempoolFillerAddress(String host) {
+        return makeRequest(host, MEMPOOL_FILLER_PATH, "GET").getString("address");
+    }
+
+    public void startMempoolFiller(String host) {
+        makeRequest(host, MEMPOOL_FILLER_PATH, "PUT", "{\"enabled\":true}");
+    }
+
+    public void stopMempoolFiller(String host) {
+        makeRequest(host, MEMPOOL_FILLER_PATH, "PUT", "{\"enabled\":false}");
+    }
+
+    private JSONObject makeRequest(String host, String path, String method) {
+        return makeRequest(host, path, method, "");
+    }
+
+    private JSONObject makeRequest(String host, String path, String method, String body) {
+        String stringResponse;
+        RequestBody requestBody = StringUtils.isBlank(body) ? null :
+                RequestBody.create(MediaType.get("application/json"), body);
+        Request request = new Request.Builder()
+                .url(protocol + host + path)
+                .method(method, requestBody)
+                .addHeader("Authorization", "Basic " + encodedBasicAuthCredentials)
+                .build();
+        try {
+            Response response = okHttpClient.newCall(request).execute();
+            if (!response.isSuccessful()) {
+                throw new ActionFailedException(String.format("%s %s%s%s - %d %s",
+                        method, protocol, host, path, response.code(), response.message()));
+            }
+            stringResponse = response.body().string();
+        } catch (IOException e) {
+            throw new ActionFailedException(e);
+        }
+
+        if (StringUtils.isBlank(stringResponse)) {
+            return new JSONObject();
+        } else {
+            return new JSONObject(stringResponse);
+        }
+    }
+
+}

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/HttpClient.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/HttpClient.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2021 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.test.chaos;
 
 import com.radixdlt.client.core.network.HttpClients;

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/HttpClient.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/HttpClient.java
@@ -2,10 +2,13 @@ package com.radixdlt.test.chaos;
 
 import com.radixdlt.client.core.network.HttpClients;
 import com.radixdlt.test.chaos.actions.ActionFailedException;
-import okhttp3.*;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.MediaType;
 import org.json.JSONObject;
 import org.junit.platform.commons.util.StringUtils;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -16,8 +19,8 @@ import java.util.Optional;
  */
 public class HttpClient {
 
-    private final static String MEMPOOL_FILLER_PATH = "/api/chaos/mempool-filler";
-    private final static String VALIDATOR_REGISTRATION_PATH = "/node/validator";
+    private static final String MEMPOOL_FILLER_PATH = "/api/chaos/mempool-filler";
+    private static final String VALIDATOR_REGISTRATION_PATH = "/node/validator";
 
     private final OkHttpClient okHttpClient;
     private final String protocol;
@@ -80,8 +83,8 @@ public class HttpClient {
 
     private JSONObject makeRequest(String host, String path, String method, String body) {
         String stringResponse;
-        RequestBody requestBody = StringUtils.isBlank(body) ? null :
-                RequestBody.create(MediaType.get("application/json"), body);
+        RequestBody requestBody = StringUtils.isBlank(body) ? null
+                : RequestBody.create(MediaType.get("application/json"), body);
         Request request = new Request.Builder()
                 .url(protocol + host + path)
                 .method(method, requestBody)

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/Action.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/Action.java
@@ -1,0 +1,12 @@
+package com.radixdlt.test.chaos.actions;
+
+/**
+ * Something which affects a testnet
+ */
+public interface Action {
+
+    void setup();
+
+    void teardown();
+
+}

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/Action.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/Action.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2021 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.test.chaos.actions;
 
 /**

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ActionFailedException.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ActionFailedException.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2021 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.test.chaos.actions;
 
 public class ActionFailedException extends Error {

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ActionFailedException.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ActionFailedException.java
@@ -1,0 +1,13 @@
+package com.radixdlt.test.chaos.actions;
+
+public class ActionFailedException extends Error {
+
+    public ActionFailedException(Exception e) {
+        super(e);
+    }
+
+    public ActionFailedException(String message) {
+        super(message);
+    }
+
+}

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ActionWithLikelihood.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ActionWithLikelihood.java
@@ -1,0 +1,40 @@
+package com.radixdlt.test.chaos.actions;
+
+import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
+import com.radixdlt.test.utils.ChaosExperimentUtils;
+
+/**
+ * An action that may or may not happen.
+ */
+public abstract class ActionWithLikelihood implements Action {
+
+    private final AnsibleImageWrapper ansible;
+    private final double likelihood;
+
+    public ActionWithLikelihood(AnsibleImageWrapper ansible, double likelihood) {
+        this.ansible = ansible;
+        this.likelihood = likelihood;
+    }
+
+    /**
+     * this is called if the likelihood check succeeded
+     */
+    abstract void setupImplementation();
+
+    @Override
+    public void setup() {
+        if (ChaosExperimentUtils.isSmallerThanFractionOfOne(likelihood)) {
+            setupImplementation();
+        }
+    }
+
+    public AnsibleImageWrapper getAnsible() {
+        return ansible;
+    }
+
+    @Override
+    public void teardown() {
+        // nothing by default
+    }
+
+}

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ActionWithLikelihood.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ActionWithLikelihood.java
@@ -1,7 +1,7 @@
 package com.radixdlt.test.chaos.actions;
 
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
-import com.radixdlt.test.utils.ChaosExperimentUtils;
+import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;
 
 /**
  * An action that may or may not happen.

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ActionWithLikelihood.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ActionWithLikelihood.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2021 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.test.chaos.actions;
 
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/MempoolFillAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/MempoolFillAction.java
@@ -27,7 +27,7 @@ public class MempoolFillAction extends ActionWithLikelihood {
 
         String addressOfFiller = httpClient.getMempoolFillerAddress(fillerNode);
         httpClient.callFaucetForAddress(addressOfFiller);
-        logger.info("Got coins");
+        logger.info("Got tokens");
 
         httpClient.startMempoolFiller(fillerNode);
         logger.info("Mempool filler started");

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/MempoolFillAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/MempoolFillAction.java
@@ -2,7 +2,7 @@ package com.radixdlt.test.chaos.actions;
 
 import com.radixdlt.test.chaos.HttpClient;
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
-import com.radixdlt.test.utils.ChaosExperimentUtils;
+import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/MempoolFillAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/MempoolFillAction.java
@@ -23,7 +23,7 @@ public class MempoolFillAction extends ActionWithLikelihood {
     public void setupImplementation() {
         String fillerNode = getAnsible().getRandomNodeHost();
         logger.info("Starting mempool filler with {}", fillerNode);
-        ChaosExperimentUtils.annotateGrafana(fillerNode + " starting the mempool filler");
+        ChaosExperimentUtils.annotateGrafana("mempool filler " + fillerNode);
 
         String addressOfFiller = httpClient.getMempoolFillerAddress(fillerNode);
         httpClient.callFaucetForAddress(addressOfFiller);

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/MempoolFillAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/MempoolFillAction.java
@@ -28,6 +28,7 @@ public class MempoolFillAction extends ActionWithLikelihood {
         String addressOfFiller = httpClient.getMempoolFillerAddress(fillerNode);
         httpClient.callFaucetForAddress(addressOfFiller);
         logger.info("Got tokens");
+        ChaosExperimentUtils.waitSeconds(5);
 
         httpClient.startMempoolFiller(fillerNode);
         logger.info("Mempool filler started");

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/MempoolFillAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/MempoolFillAction.java
@@ -1,0 +1,46 @@
+package com.radixdlt.test.chaos.actions;
+
+import com.radixdlt.test.chaos.HttpClient;
+import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
+import com.radixdlt.test.utils.ChaosExperimentUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class MempoolFillAction extends ActionWithLikelihood {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final int durationInSeconds;
+    private final HttpClient httpClient;
+
+    public MempoolFillAction(AnsibleImageWrapper ansible, double likelihood, int durationInSeconds) {
+        super(ansible, likelihood);
+        this.durationInSeconds = durationInSeconds;
+        httpClient = new HttpClient();
+    }
+
+    @Override
+    public void setupImplementation() {
+        String fillerNode = getAnsible().getRandomNodeHost();
+        logger.info("Starting mempool filler with {}", fillerNode);
+        ChaosExperimentUtils.annotateGrafana(fillerNode + " starting the mempool filler");
+
+        String addressOfFiller = httpClient.getMempoolFillerAddress(fillerNode);
+        httpClient.callFaucetForAddress(addressOfFiller);
+        logger.info("Got coins");
+
+        httpClient.startMempoolFiller(fillerNode);
+        logger.info("Mempool filler started");
+
+        ChaosExperimentUtils.waitSeconds(durationInSeconds);
+
+        httpClient.stopMempoolFiller(fillerNode);
+        logger.info("Mempool filler stopped");
+    }
+
+    @Override
+    public void teardown() {
+        getAnsible().getNodeAddressList().forEach(httpClient::stopMempoolFiller);
+    }
+
+}

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/NetworkAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/NetworkAction.java
@@ -1,9 +1,28 @@
+/*
+ * (C) Copyright 2021 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.test.chaos.actions;
 
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
 import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.Random;
 
 public class NetworkAction extends ActionWithLikelihood {
 
@@ -15,16 +34,25 @@ public class NetworkAction extends ActionWithLikelihood {
 
     @Override
     public void setupImplementation() {
-        String tcOptions = "loss 3% delay 50ms";
+        String tcOptions = getRandomLatencyOrLoss();
         getAnsible().runPlaybook("slow-down-node.yml", tcOptions, "setup");
         ChaosExperimentUtils.annotateGrafana(tcOptions);
-        logger.info("Applied network effects");
+        logger.info("Applied network effects " + tcOptions);
     }
 
     @Override
     public void teardown() {
         logger.info("Removing any network effects...");
         getAnsible().runPlaybook("slow-down-node.yml", "teardown");
+    }
+
+    private String getRandomLatencyOrLoss() {
+        Random random = new Random();
+        if (random.nextBoolean()) { // loss
+            return "loss " + (random.nextInt(10) + 1) + "%";
+        } else { // delay
+            return "delay " + (random.nextInt(25) + 1) + "ms";
+        }
     }
 
 }

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/NetworkAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/NetworkAction.java
@@ -1,7 +1,7 @@
 package com.radixdlt.test.chaos.actions;
 
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
-import com.radixdlt.test.utils.ChaosExperimentUtils;
+import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/NetworkAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/NetworkAction.java
@@ -1,0 +1,30 @@
+package com.radixdlt.test.chaos.actions;
+
+import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
+import com.radixdlt.test.utils.ChaosExperimentUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class NetworkAction extends ActionWithLikelihood {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    public NetworkAction(AnsibleImageWrapper ansible, double likelihood) {
+        super(ansible, likelihood);
+    }
+
+    @Override
+    public void setupImplementation() {
+        String tcOptions = "loss 3% delay 50ms";
+        getAnsible().runPlaybook("slow-down-node.yml", tcOptions, "setup");
+        ChaosExperimentUtils.annotateGrafana(tcOptions);
+        logger.info("Applied network effects");
+    }
+
+    @Override
+    public void teardown() {
+        logger.info("Removing any network effects...");
+        getAnsible().runPlaybook("slow-down-node.yml", "teardown");
+    }
+
+}

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/RestartAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/RestartAction.java
@@ -1,7 +1,7 @@
 package com.radixdlt.test.chaos.actions;
 
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
-import com.radixdlt.test.utils.ChaosExperimentUtils;
+import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/RestartAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/RestartAction.java
@@ -1,0 +1,24 @@
+package com.radixdlt.test.chaos.actions;
+
+import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
+import com.radixdlt.test.utils.ChaosExperimentUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class RestartAction extends ActionWithLikelihood {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    public RestartAction(AnsibleImageWrapper ansible, double likelihood) {
+        super(ansible, likelihood);
+    }
+
+    @Override
+    public void setupImplementation() {
+        logger.info("Restarting a random node...");
+        String randomHost = getAnsible().getRandomNodeHost();
+        ChaosExperimentUtils.runCommandOverSsh(randomHost, "docker restart radixdlt_core_1");
+        ChaosExperimentUtils.annotateGrafana("docker restart " + randomHost);
+    }
+
+}

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/RestartAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/RestartAction.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2021 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.test.chaos.actions;
 
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ShutdownAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ShutdownAction.java
@@ -1,7 +1,7 @@
 package com.radixdlt.test.chaos.actions;
 
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
-import com.radixdlt.test.utils.ChaosExperimentUtils;
+import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ShutdownAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ShutdownAction.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2021 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.test.chaos.actions;
 
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ShutdownAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ShutdownAction.java
@@ -1,0 +1,32 @@
+package com.radixdlt.test.chaos.actions;
+
+import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
+import com.radixdlt.test.utils.ChaosExperimentUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class ShutdownAction extends ActionWithLikelihood {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    public ShutdownAction(AnsibleImageWrapper ansible, double shutdownLikelihood) {
+        super(ansible, shutdownLikelihood);
+    }
+
+    @Override
+    void setupImplementation() {
+        String randomNodeHost = getAnsible().getRandomNodeHost();
+        logger.info("Shutting down {}", randomNodeHost);
+        ChaosExperimentUtils.runCommandOverSsh(randomNodeHost, "docker stop radixdlt_core_1");
+        ChaosExperimentUtils.annotateGrafana("docker stop " + randomNodeHost);
+    }
+
+    @Override
+    public void teardown() {
+        logger.info("Bringing up all nodes...");
+        getAnsible().getNodeAddressList().forEach(nodeAddress -> {
+            ChaosExperimentUtils.runCommandOverSsh(nodeAddress, "docker start radixdlt_core_1");
+        });
+    }
+
+}

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ValidatorRegistrationAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ValidatorRegistrationAction.java
@@ -2,6 +2,7 @@ package com.radixdlt.test.chaos.actions;
 
 import com.radixdlt.test.chaos.HttpClient;
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
+import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -19,8 +20,15 @@ public class ValidatorRegistrationAction extends ActionWithLikelihood {
     @Override
     public void setupImplementation() {
         String host = getAnsible().getRandomNodeHost();
+
+        String addressOfFiller = httpClient.getMempoolFillerAddress(host);
+        httpClient.callFaucetForAddress(addressOfFiller);
+        logger.info("Got tokens");
+        ChaosExperimentUtils.waitSeconds(5);
+
         httpClient.unregisterValidator(host);
-        logger.info("Unregistered node {} as a validaotr", host);
+        logger.info("Unregistered node {} as a validator", host);
+        ChaosExperimentUtils.annotateGrafana("Unregistered " + host);
     }
 
     @Override

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ValidatorRegistrationAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ValidatorRegistrationAction.java
@@ -1,0 +1,32 @@
+package com.radixdlt.test.chaos.actions;
+
+import com.radixdlt.test.chaos.HttpClient;
+import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class ValidatorRegistrationAction extends ActionWithLikelihood {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final HttpClient httpClient;
+
+    public ValidatorRegistrationAction(AnsibleImageWrapper ansible, double likelihood) {
+        super(ansible, likelihood);
+        httpClient = new HttpClient();
+    }
+
+    @Override
+    public void setupImplementation() {
+        String host = getAnsible().getRandomNodeHost();
+        httpClient.unregisterValidator(host);
+        logger.info("Unregistered node {} as a validaotr", host);
+    }
+
+    @Override
+    public void teardown() {
+        logger.info("Registering all nodes as validators");
+        getAnsible().getNodeAddressList().forEach(httpClient::registerValidator);
+    }
+
+}

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ansible/AnsibleImageWrapper.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ansible/AnsibleImageWrapper.java
@@ -1,0 +1,120 @@
+package com.radixdlt.test.chaos.ansible;
+
+import com.radixdlt.test.RemoteBFTNetwork;
+import com.radixdlt.test.StaticClusterNetwork;
+import com.radixdlt.test.utils.ChaosExperimentUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.assertj.core.util.Lists;
+import org.assertj.core.util.Sets;
+import org.junit.platform.commons.util.StringUtils;
+import utils.CmdHelper;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * We have our own image with ansible and several playbook. We use this image via docker.
+ * This class has the docker commands needed to utilize these playbooks.
+ */
+public class AnsibleImageWrapper {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    public static final String DEFAULT_ANSIBLE_IMAGE = "eu.gcr.io/lunar-arc-236318/node-ansible";
+    private static final String KEY_VOLUME_NAME_USED_FOR_COPYING = "key-volume";
+
+    private final String image;
+    private final String clusterName;
+    private Set<String> nodeAddresses;
+
+    public static AnsibleImageWrapper createWithDefaultImage() {
+        String sshKeyLocation = ChaosExperimentUtils.getSshIdentityLocation();
+        String clusterName = Optional.ofNullable(System.getenv("TESTNET_NAME")).orElseThrow();
+        // the ansible image needs an SSH key because it runs tasks over SSH
+        AnsibleImageWrapper wrapper = new AnsibleImageWrapper(DEFAULT_ANSIBLE_IMAGE, clusterName);
+        wrapper.copyfileToNamedVolume(sshKeyLocation);
+        wrapper.pullImage();
+        return wrapper;
+    }
+
+    private AnsibleImageWrapper(String image, String clusterName) {
+        this.image = image;
+        this.clusterName = clusterName;
+    }
+
+    /**
+     * The key needs to be copied to a volume, which is created with the help of a temp dummy container
+     */
+    private void copyfileToNamedVolume(String localFileLocation) {
+        CmdHelper.runCommand(String.format("docker container create --name dummy -v %s:%s curlimages/curl:7.70.0",
+                KEY_VOLUME_NAME_USED_FOR_COPYING, "/ansible/ssh"));
+        CmdHelper.runCommand(String.format("docker cp %s dummy:%s",
+                localFileLocation, "/ansible/ssh/testnet"));
+        CmdHelper.runCommand("docker rm -f dummy");
+    }
+
+    private void pullImage() {
+        CmdHelper.runCommand("docker pull " + image);
+    }
+
+    public String runPlaybook(String playbook, String options, String tag) {
+        String optionsAsEnvProperty = StringUtils.isBlank(options) ? "" : "-e optionsArgs=\"" + options + "\" ";
+        String command = "docker run --rm -v key-volume:/ansible/ssh --name node-ansible "
+                + image + " "
+                + playbook + " "
+                + optionsAsEnvProperty
+                + "--limit " + clusterName + " -t " + tag;
+        return CmdHelper.runCommand(command.split("\\s")).toString();
+    }
+
+    public String runPlaybook(String playbook, String tag) {
+        return runPlaybook(playbook, null, tag);
+    }
+
+    /**
+     * Uses the output of the check task to get a list of node IPs
+     */
+    public Set<String> getNodeAddressList() {
+        if (nodeAddresses == null) {
+            nodeAddresses = Sets.newHashSet();
+            String playbookOutput = runPlaybook("check.yml", "check");
+            Matcher matcher = Pattern.compile("(?<=\\[).+?(?=\\])").matcher(playbookOutput);
+            while (matcher.find()) {
+                String raw = matcher.group(0);
+                if (raw.split("[.]").length == 4) {
+                    nodeAddresses.add(raw);
+                }
+            }
+            logger.info("Found {} nodes", nodeAddresses.size());
+        }
+        return nodeAddresses;
+    }
+
+    /**
+     * returns one of the node addresses
+     */
+    public String getRandomNodeHost() {
+        List<String> addressList = Lists.newArrayList(getNodeAddressList());
+        return addressList.get(new Random().nextInt(addressList.size()));
+    }
+
+    /**
+     * This is needed to bridge the older code (using {@link RemoteBFTNetwork} and the tests here.
+     * Hardcoded to HTTPS, but can be externalized to a property.
+     */
+    public RemoteBFTNetwork toNetwork() {
+        return StaticClusterNetwork.from(getNodeAddressList().stream().map(address -> "https://" + address)
+                .collect(Collectors.toSet()));
+    }
+
+    public void tearDown() {
+        CmdHelper.runCommand("docker volume rm -f " + KEY_VOLUME_NAME_USED_FOR_COPYING);
+    }
+
+}

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ansible/AnsibleImageWrapper.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ansible/AnsibleImageWrapper.java
@@ -2,7 +2,7 @@ package com.radixdlt.test.chaos.ansible;
 
 import com.radixdlt.test.RemoteBFTNetwork;
 import com.radixdlt.test.StaticClusterNetwork;
-import com.radixdlt.test.utils.ChaosExperimentUtils;
+import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.assertj.core.util.Lists;

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ansible/AnsibleImageWrapper.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ansible/AnsibleImageWrapper.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2021 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.test.chaos.ansible;
 
 import com.radixdlt.test.RemoteBFTNetwork;
@@ -64,12 +81,13 @@ public class AnsibleImageWrapper {
     }
 
     public String runPlaybook(String playbook, String options, String tag) {
-        String optionsAsEnvProperty = StringUtils.isBlank(options) ? "" : "-e optionsArgs=\"" + options + "\" ";
+        String optionsAsEnvProperty = StringUtils.isBlank(options) ? "" : "-e \"optionsArgs='" + options + "'\" ";
         String command = "docker run --rm -v key-volume:/ansible/ssh --name node-ansible "
                 + image + " "
                 + playbook + " "
                 + optionsAsEnvProperty
                 + "--limit " + clusterName + " -t " + tag;
+        logger.debug("Running command: {}", command);
         return CmdHelper.runCommand(command.split("\\s")).toString();
     }
 

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/utils/ChaosExperimentUtils.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/utils/ChaosExperimentUtils.java
@@ -27,6 +27,10 @@ import static org.awaitility.Awaitility.await;
 
 public class ChaosExperimentUtils {
 
+    private ChaosExperimentUtils() {
+        // for checkstyle
+    }
+
     private static final Logger logger = LogManager.getLogger();
 
     /**

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/utils/ChaosExperimentUtils.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/utils/ChaosExperimentUtils.java
@@ -64,7 +64,7 @@ public class ChaosExperimentUtils {
     public static void waitSeconds(int seconds) {
         long start = System.currentTimeMillis();
         await().atMost(10, TimeUnit.MINUTES)
-                .until(() -> (System.currentTimeMillis() > start + 1000L * seconds));
+                .until(() -> (System.currentTimeMillis() > start + (1000L * seconds)));
     }
 
     public static String getSshIdentityLocation() {

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/utils/ChaosExperimentUtils.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/utils/ChaosExperimentUtils.java
@@ -80,7 +80,7 @@ public class ChaosExperimentUtils {
 
     public static void waitSeconds(int seconds) {
         long start = System.currentTimeMillis();
-        await().atMost(10, TimeUnit.MINUTES)
+        await().atMost(50, TimeUnit.MINUTES)
                 .until(() -> (System.currentTimeMillis() > start + (1000L * seconds)));
     }
 

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/utils/ChaosExperimentUtils.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/utils/ChaosExperimentUtils.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2021 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.test.chaos.utils;
 
 import com.jcraft.jsch.ChannelExec;

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/utils/ChaosExperimentUtils.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/utils/ChaosExperimentUtils.java
@@ -1,4 +1,4 @@
-package com.radixdlt.test.utils;
+package com.radixdlt.test.chaos.utils;
 
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSch;

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/utils/ChaosExperimentUtils.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/utils/ChaosExperimentUtils.java
@@ -1,0 +1,113 @@
+package com.radixdlt.test.utils;
+
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import com.radixdlt.client.core.network.HttpClients;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.platform.commons.util.StringUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+
+public class ChaosExperimentUtils {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    /**
+     * Will pseudo-randomly generate a number between 0 and 1 and will return true if its greater than the given threshold
+     */
+    public static boolean isSmallerThanFractionOfOne(double threshold) {
+        return BigDecimal.valueOf(Math.random()).compareTo(BigDecimal.valueOf(threshold)) == -1;
+    }
+
+    public static void annotateGrafana(String text) {
+        String token = System.getenv("GRAFANA_TOKEN");
+        String dashboardId = System.getenv("GRAFANA_DASHBOARD_ID");
+        if (StringUtils.isBlank(token) || StringUtils.isBlank(dashboardId)) {
+            logger.warn("No GRAFANA_TOKEN or GRAFANA_DASHBOARD_ID provided, will not annotate");
+        } else {
+            String payload = createJsonString(text, dashboardId);
+            Request annotationRequest = new Request.Builder()
+                    .addHeader("Authorization", "Bearer " + token)
+                    .addHeader("Content-Type", "application/json")
+                    .method("POST", RequestBody.create(MediaType.get("application/json"), payload))
+                    .url("https://radixdlt.grafana.net/api/annotations")
+                    .build();
+            try {
+                HttpClients.getSslAllTrustingClient().newCall(annotationRequest).execute();
+            } catch (IOException e) {
+                logger.error(e);
+            }
+        }
+    }
+
+    public static void waitSeconds(int seconds) {
+        long start = System.currentTimeMillis();
+        await().atMost(10, TimeUnit.MINUTES)
+                .until(() -> (System.currentTimeMillis() > start + 1000L * seconds));
+    }
+
+    public static String getSshIdentityLocation() {
+        return Optional.ofNullable(System.getenv("SSH_IDENTITY")).orElse(System.getenv("HOME") + "/.ssh/id_rsa");
+    }
+
+    public static String runCommandOverSsh(String host, String command) {
+        JSch jsch = new JSch();
+        Session session = null;
+        ChannelExec channelExec = null;
+        try {
+            jsch.addIdentity(getSshIdentityLocation());
+            session = jsch.getSession("radix", host, 22);
+            Properties config = new java.util.Properties();
+            config.put("StrictHostKeyChecking", "no");
+            session.setConfig(config);
+            session.connect();
+
+            channelExec = (ChannelExec) session.openChannel("exec");
+            channelExec.setCommand(command);
+            channelExec.setErrStream(System.err);
+            InputStream in = channelExec.getInputStream();
+            channelExec.connect(5000);
+
+            String commandOutput = IOUtils.toString(in, StandardCharsets.UTF_8);
+            if (channelExec.getExitStatus() == 1) {
+                throw new RuntimeException("Command " + command + " failed, see log.");
+            }
+            return commandOutput;
+        } catch (JSchException | IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            session.disconnect();
+            if (channelExec != null) {
+                channelExec.disconnect();
+            }
+        }
+    }
+
+    private static String createJsonString(String text, String dashboardId) {
+        JSONObject requestJson = new JSONObject();
+        requestJson.put("dashboardId", Integer.parseInt(dashboardId));
+        requestJson.put("text", text);
+        JSONArray tagArray = new JSONArray();
+        tagArray.put("chaos");
+        requestJson.put("tags", tagArray);
+        return requestJson.toString();
+    }
+
+}


### PR DESCRIPTION
Added a chaos experiment which should run against a testnet (milestonenet).

The test is found in the [ChaosTest ](https://github.com/radixdlt/radixdlt/blob/task/add_chaos_to_testnet/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosTests.java)class. It works like this:

- Make sure we got liveness
- Perform several actions against the network
- Make sure we still got liveness

The actions do things like add network latency or restart containers. They can be found under [com.radixdlt.test.chaos.actions](https://github.com/radixdlt/radixdlt/tree/task/add_chaos_to_testnet/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions). They use ansible and [JSch](http://www.jcraft.com/jsch/) to do stuff to the network.

They are meant to be run from Jenkins periodically, which is why each action has a random chance of getting applied.