### PR TITLE
Working ECIES with DH addition

### DIFF
--- a/radixdlt-java-common/src/main/java/com/radixdlt/crypto/encryption/SymmetricKeyDerivationFunction.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/crypto/encryption/SymmetricKeyDerivationFunction.java
@@ -1,0 +1,44 @@
+package com.radixdlt.crypto.encryption;/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import com.radixdlt.crypto.ECMultiplicationScalar;
+import com.radixdlt.crypto.ECPublicKey;
+import org.bouncycastle.math.ec.ECPoint;
+
+import javax.crypto.SecretKey;
+
+public interface SymmetricKeyDerivationFunction {
+
+	<S extends ECMultiplicationScalar> SecretKey derive(
+		ECPoint ephemeralPublicKeyPoint,
+		S blackPrivateKey,
+		ECPoint whitePublicKeyPoint
+	);
+
+	default <S extends ECMultiplicationScalar> SecretKey derive(
+		ECPublicKey ephemeralPublicKey,
+		S blackPrivateKey,
+		ECPublicKey whitePublicKey
+	) {
+		return derive(
+			ephemeralPublicKey.getPublicPoint(),
+			blackPrivateKey,
+			whitePublicKey.getPublicPoint()
+		);
+	}
+
+}

--- a/radixdlt-java-common/src/test/java/com/radixdlt/crypto/encryption/ECIESTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/crypto/encryption/ECIESTest.java
@@ -19,12 +19,15 @@ package com.radixdlt.crypto.encryption;
 
 import com.radixdlt.TestSetupUtils;
 import com.radixdlt.crypto.ECKeyPair;
+import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.crypto.exception.ECIESException;
 import com.radixdlt.crypto.exception.PrivateKeyException;
 import com.radixdlt.crypto.exception.PublicKeyException;
 import com.radixdlt.utils.Bytes;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 
@@ -147,5 +150,23 @@ public class ECIESTest {
 			throw new IllegalStateException("Can't create test key", e);
 		}
 	}
-}
+
+	@Test
+	public void test_cyon() throws PublicKeyException, PrivateKeyException, ECIESException {
+
+		var senderPubKey = ECPublicKey.fromBytes(Bytes.fromHexString("04DB4BFDF2B5CDAF06D83746D9C483C1DD0E2513B2F95A2AF176B7BCAC9733CD588FB3123601009C162881B1B3F024EFF9F07F7A1F5FCC0B1D811B19999A635FCA"));
+		var privateKey = ECKeyPair.fromPrivateKey(Bytes.fromHexString("4BA74772420949170E44338B5410B37C314BAD295FBE07C0D1A612A345E9E149"));
+		var encryptedMessage = Bytes.fromHexString("ee5c74e22e6f37a041c057920320a2fab2a78c18ea875c9699000a56bba4409da4ad617c41629be6ee30ccf6971117593f9091b54c4b7a782fc5a9cb768bcabb38c637ea20ae6efd9d7f60161f162cfe48e79e1db3cb3c802521e1bdea2be134ad0938ec52ec218a794e38b8f29620ff7e031e016eece8c477e14a6ccc188809e35023d07dd663fedff837");
+
+		var decryped = ECIES.open(
+			new ECIES.ECAddDiffieHellmanKDF(),
+			ECIES.SealedBox.fromBytes(encryptedMessage),
+			senderPubKey,
+			privateKey
+		);
+
+		var msg = new String(decryped, StandardCharsets.UTF_8);
+
+		assertEquals("Guten tag Joe! My nukes are 100 miles south west of Münich, don't tell anyone", msg);
+	}}
 


### PR DESCRIPTION
Working POC (with test) of ["Cyon" ECIES](https://crypto.stackexchange.com/q/88083/60476) using [AES GCM](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Galois/counter_(GCM)) instead of [AES CBC](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_block_chaining_(CBC)) + [HMAC](https://en.wikipedia.org/wiki/HMAC).

Note, we replace two steps AES-CBC and HMAC with just AES-GCM, since GCM has authentication built in.

This is not meant to be a final implementation, but could easily refactored and tidied up to be! It proves that we have two cross library compatible implementations of this new "virtually symmetric" encryption scheme. By "virtually symmetric" I mean that it is still Elliptic Curve based asymmetric encryption, using symmetric encryption (AES) internally, but thanks to DiffieHellman key exchange + extra safety thanks to the addition of an ephemeral point, **_we enable both recipient AND sender to be able to decrypt the message_** - without any application layer constructs.

[Corresponding POC in Swift (Cyons lib "EllipticCurveKit")](https://github.com/Sajjon/EllipticCurveKit/pull/18), note exact same test vector as implemented in this PR on [those lines](https://github.com/Sajjon/EllipticCurveKit/blob/7fcb193d976c39ce3f3202be79cb10406f081e8e/Tests/EllipticCurveKitTests/Crypto/ECIESTests.swift#L126-L133).