### PR TITLE
Cluster test fix

### DIFF
--- a/radixdlt-regression/system-tests/build.gradle
+++ b/radixdlt-regression/system-tests/build.gradle
@@ -64,6 +64,7 @@ task copyCLIJar {
         }
     }
 }
+
 task bddTest(type: Test) {
     dependsOn clean,copyCLIJar
     testLogging.showStandardStreams = true
@@ -96,6 +97,18 @@ task clusterSystemTests(type: Test) {
     testLogging.showStandardStreams = true
     systemProperties System.getProperties()
     exclude "Runner.class"
+    jacoco {
+        // We don't want these tests included in code coverage.
+        enabled false
+    }
+}
+
+task chaosExperiments(type: Test) {
+    filter {
+        includeTestsMatching "com.radixdlt.test.chaos.*"
+    }
+    testLogging.showStandardStreams = true
+    systemProperties System.getProperties()
     jacoco {
         // We don't want these tests included in code coverage.
         enabled false

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
@@ -17,23 +17,15 @@
 
 package com.radixdlt.test.chaos;
 
-import com.radixdlt.test.Cluster;
-import com.radixdlt.test.chaos.actions.Action;
-import com.radixdlt.test.chaos.actions.NetworkAction;
-import com.radixdlt.test.chaos.actions.RestartAction;
-import com.radixdlt.test.chaos.actions.ValidatorUnregistrationAction;
-import com.radixdlt.test.chaos.actions.ShutdownAction;
-import com.radixdlt.test.chaos.actions.MempoolFillAction;
+import com.radixdlt.test.chaos.actions.*;
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
 import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import java.util.Set;
 
-@Category(Cluster.class)
 public class ChaosExperiments {
 
     private static final Logger logger = LogManager.getLogger();

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
@@ -17,7 +17,13 @@
 
 package com.radixdlt.test.chaos;
 
-import com.radixdlt.test.chaos.actions.*;
+import com.radixdlt.test.Cluster;
+import com.radixdlt.test.chaos.actions.Action;
+import com.radixdlt.test.chaos.actions.NetworkAction;
+import com.radixdlt.test.chaos.actions.RestartAction;
+import com.radixdlt.test.chaos.actions.ValidatorUnregistrationAction;
+import com.radixdlt.test.chaos.actions.ShutdownAction;
+import com.radixdlt.test.chaos.actions.MempoolFillAction;
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
 import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;
 import org.apache.logging.log4j.LogManager;

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
@@ -17,7 +17,6 @@
 
 package com.radixdlt.test.chaos;
 
-import com.radixdlt.test.Cluster;
 import com.radixdlt.test.chaos.actions.Action;
 import com.radixdlt.test.chaos.actions.NetworkAction;
 import com.radixdlt.test.chaos.actions.RestartAction;


### PR DESCRIPTION
One reason the tests were failing was the chaos experiment was also included (it shouldn't be).