### PR TITLE
fix release drafter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,18 @@ name: Unit, integration tests and sonar
 on: [pull_request]
 
 jobs:
-  build:
-    name: Unit tests and sonarqube
+  cancel_running_workflows:
+    name: Cancel running workflows
     runs-on: ubuntu-20.04
     steps:
       - name: cancel running workflows
         uses: styfle/cancel-workflow-action@0.8.0
         with:
           access_token: ${{ github.token }}
+  build:
+    name: Unit tests and sonarqube
+    runs-on: ubuntu-20.04
+    steps:
       - uses: actions/checkout@v2
         with:
           # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ on:
  push:
    # branches to consider in the event; optional, defaults to all
    branches:
-     - rc*
+     - rc\/*
 jobs:
  update_release_draft:
    runs-on: ubuntu-latest


### PR DESCRIPTION
- fix branch regex for release-drafter
- run job to cancel existing running workflows in parallel to speed up the process 