### PR TITLE
Update chaos experiment to run against Relasenet

### DIFF
--- a/radixdlt-core/docker/core.yml
+++ b/radixdlt-core/docker/core.yml
@@ -1,7 +1,5 @@
 version: '2.1'
 
-
-
 services:
   core:
     build:

--- a/radixdlt-core/docker/core.yml
+++ b/radixdlt-core/docker/core.yml
@@ -1,5 +1,7 @@
 version: '2.1'
 
+
+
 services:
   core:
     build:

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
@@ -45,12 +45,15 @@ public class ChaosExperiments {
                 new NetworkAction(ansible, 0.4),
                 new RestartAction(ansible, 0.7),
                 new ShutdownAction(ansible, 0.1),
-                new MempoolFillAction(ansible, 0.7, 300),
+                //new MempoolFillAction(ansible, 0.7, 300),
                 new ValidatorUnregistrationAction(ansible, 1.0)
         );
 
         actions.forEach(Action::teardown);
-        actions.forEach(Action::setup);
+        actions.forEach(action -> {
+            action.setup();
+            ChaosExperimentUtils.waitSeconds(20);
+        });
 
         ChaosExperimentUtils.livenessCheckIgnoringOffline(ansible.toNetwork());
     }

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
@@ -45,7 +45,7 @@ public class ChaosExperiments {
                 new NetworkAction(ansible, 0.4),
                 new RestartAction(ansible, 0.7),
                 new ShutdownAction(ansible, 0.1),
-                //new MempoolFillAction(ansible, 0.7, 300),
+                //new MempoolFillAction(ansible, 0.7, 300), TODO disabled because this brings down the node
                 new ValidatorUnregistrationAction(ansible, 1.0)
         );
 

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
@@ -22,7 +22,6 @@ import com.radixdlt.test.chaos.actions.NetworkAction;
 import com.radixdlt.test.chaos.actions.RestartAction;
 import com.radixdlt.test.chaos.actions.ValidatorUnregistrationAction;
 import com.radixdlt.test.chaos.actions.ShutdownAction;
-import com.radixdlt.test.chaos.actions.MempoolFillAction;
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
 import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;
 import org.apache.logging.log4j.LogManager;

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
@@ -42,11 +42,11 @@ public class ChaosExperiments {
         ChaosExperimentUtils.livenessCheckIgnoringOffline(ansible.toNetwork());
 
         Set<Action> actions = Set.of(
-                new NetworkAction(ansible, 0.4),
-                new RestartAction(ansible, 0.7),
+                new NetworkAction(ansible, 0.3),
+                new RestartAction(ansible, 0.6),
                 new ShutdownAction(ansible, 0.1),
                 //new MempoolFillAction(ansible, 0.7, 300), TODO disabled because this brings down the node
-                new ValidatorUnregistrationAction(ansible, 1.0)
+                new ValidatorUnregistrationAction(ansible, 0.5)
         );
 
         actions.forEach(Action::teardown);

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/HttpClient.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/HttpClient.java
@@ -38,6 +38,7 @@ public class HttpClient {
 
     private static final String MEMPOOL_FILLER_PATH = "/api/chaos/mempool-filler";
     private static final String NODE_INFO_PATH = "/node";
+    private static final String FAUCET_REQUEST_PATH = "/faucet/request";
     private static final String VALIDATOR_REGISTRATION_PATH = "/node/validator";
 
     private final OkHttpClient okHttpClient;
@@ -54,16 +55,22 @@ public class HttpClient {
         protocol = isHttps ? "https://" : "http://";
         String basicAuthCredentials = System.getenv("HTTP_API_BASIC_AUTH");
         faucetUrl = Optional.ofNullable(System.getenv("FAUCET_URL"))
-                .orElse("https://milestonenet-faucet.radixdlt.com/faucet/api/v1/getTokens/");
+                .orElse("https://rcnet-node0-faucet.radixdlt.com");
         if (StringUtils.isNotBlank(basicAuthCredentials)) {
             this.encodedBasicAuthCredentials = Base64.getEncoder()
                     .encodeToString(basicAuthCredentials.getBytes(StandardCharsets.UTF_8));
         }
     }
 
-    public void callFaucetForAddress(String address) {
+    /**
+     * Will send 10XRD to the given address
+     */
+    public void callFaucet(String addressToSendTokensTo) {
+        String json = "{\"params\":{\"address\":\"" + addressToSendTokensTo + "\"}}";
+        RequestBody body = RequestBody.create(MediaType.parse("application/json"),json);
         try (Response response = okHttpClient.newCall(new Request.Builder()
-                .url(faucetUrl + address)
+                .url(faucetUrl + FAUCET_REQUEST_PATH)
+                .method("POST", body)
                 .build()).execute()) {
             if (!response.isSuccessful()) {
                 throw new RuntimeException("Could not call faucet, request: " + response);

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/HttpClient.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/HttpClient.java
@@ -67,7 +67,7 @@ public class HttpClient {
      */
     public void callFaucet(String addressToSendTokensTo) {
         String json = "{\"params\":{\"address\":\"" + addressToSendTokensTo + "\"}}";
-        RequestBody body = RequestBody.create(MediaType.parse("application/json"),json);
+        RequestBody body = RequestBody.create(MediaType.parse("application/json"), json);
         try (Response response = okHttpClient.newCall(new Request.Builder()
                 .url(faucetUrl + FAUCET_REQUEST_PATH)
                 .method("POST", body)

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/MempoolFillAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/MempoolFillAction.java
@@ -25,11 +25,6 @@ public class MempoolFillAction extends ActionWithLikelihood {
         logger.info("Starting mempool filler from {}", fillerNode);
         ChaosExperimentUtils.annotateGrafana("mempool filler " + fillerNode);
 
-        String addressOfFiller = httpClient.getMempoolFillerAddress(fillerNode);
-        httpClient.callFaucetForAddress(addressOfFiller);
-        logger.info("Got tokens");
-        ChaosExperimentUtils.waitSeconds(5);
-
         httpClient.startMempoolFiller(fillerNode);
         logger.info("Mempool filler started");
 

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/NetworkAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/NetworkAction.java
@@ -49,9 +49,9 @@ public class NetworkAction extends ActionWithLikelihood {
     private String getRandomLatencyOrLoss() {
         Random random = new Random();
         if (random.nextBoolean()) { // loss
-            return "loss " + (random.nextInt(10) + 1) + "%";
+            return "loss " + (random.nextInt(5) + 1) + "%";
         } else { // delay
-            return "delay " + (random.nextInt(25) + 1) + "ms";
+            return "delay " + (random.nextInt(10) + 1) + "ms";
         }
     }
 

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ValidatorUnregistrationAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ValidatorUnregistrationAction.java
@@ -22,7 +22,7 @@ public class ValidatorUnregistrationAction extends ActionWithLikelihood {
         String host = getAnsible().getRandomNodeHost();
 
         String address = httpClient.getNodeAddress(host);
-        httpClient.callFaucetForAddress(address);
+        httpClient.callFaucet(address);
         logger.info("Got tokens");
         ChaosExperimentUtils.waitSeconds(5);
 

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ValidatorUnregistrationAction.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/actions/ValidatorUnregistrationAction.java
@@ -21,11 +21,6 @@ public class ValidatorUnregistrationAction extends ActionWithLikelihood {
     public void setupImplementation() {
         String host = getAnsible().getRandomNodeHost();
 
-        String address = httpClient.getNodeAddress(host);
-        httpClient.callFaucet(address);
-        logger.info("Got tokens");
-        ChaosExperimentUtils.waitSeconds(5);
-
         try {
             httpClient.unregisterValidator(host);
             logger.info("Unregistered node {} as a validator", host);


### PR DESCRIPTION
Some small changes which make [ChaosExperiments.java](https://github.com/radixdlt/radixdlt/blob/173677fb0de28a1613bf4e1d246ff072f7b20704/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java) compatible with releasenet (beta.28).

FYI I have been running this for almost a day: [Grafana Link]( https://radixdlt.grafana.net/d/1jiiTDJMk/releasenet-monitoring?viewPanel=13&orgId=1&from=1618410001369&to=1618485990438). 

You can see how much it messes with the network. However, the network still has liveness and can still accept transactions. So it looks good so far.