### PR TITLE
Use uncompressed representation for ECPublicKey equality

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/universe/Universe.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/universe/Universe.java
@@ -357,7 +357,7 @@ public class Universe {
 	@JsonProperty("creator")
 	@DsonOutput(Output.ALL)
 	private byte[] getJsonCreator() {
-		return this.creator.getBytes();
+		return this.creator.getCompressedBytes();
 	}
 
 	@JsonProperty("creator")

--- a/radixdlt-java-common/src/main/java/com/radixdlt/crypto/BouncyCastleKeyHandler.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/crypto/BouncyCastleKeyHandler.java
@@ -33,6 +33,7 @@ import com.radixdlt.SecurityCritical;
 import com.radixdlt.SecurityCritical.SecurityKind;
 import com.radixdlt.crypto.exception.PrivateKeyException;
 import com.radixdlt.crypto.exception.PublicKeyException;
+import org.bouncycastle.math.ec.ECPoint;
 
 import java.math.BigInteger;
 import java.security.KeyFactory;
@@ -71,10 +72,10 @@ final class BouncyCastleKeyHandler implements KeyHandler {
 	}
 
 	@Override
-	public boolean verify(byte[] hash, ECDSASignature signature, byte[] publicKey) {
+	public boolean verify(byte[] hash, ECDSASignature signature, ECPoint publicKeyPoint) {
 		var verifier = new ECDSASigner();
 
-		verifier.init(false, new ECPublicKeyParameters(spec.getCurve().decodePoint(publicKey), domain));
+		verifier.init(false, new ECPublicKeyParameters(publicKeyPoint, domain));
 
 		return verifier.verifySignature(hash, signature.getR(), signature.getS());
 	}

--- a/radixdlt-java-common/src/main/java/com/radixdlt/crypto/ECKeyPair.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/crypto/ECKeyPair.java
@@ -70,7 +70,7 @@ public final class ECKeyPair implements Signing<ECDSASignature> {
 			ECPrivateKeyParameters privParams = (ECPrivateKeyParameters) keypair.getPrivate();
 			ECPublicKeyParameters pubParams = (ECPublicKeyParameters) keypair.getPublic();
 
-			final ECPublicKey publicKey = ECPublicKey.fromBytes(pubParams.getQ().getEncoded(true));
+			final ECPublicKey publicKey = new ECPublicKey(pubParams.getQ());
 			byte[] privateKeyBytes = ECKeyUtils.adjustArray(privParams.getD().toByteArray(), BYTES);
 			ECKeyUtils.validatePrivate(privateKeyBytes);
 
@@ -137,7 +137,7 @@ public final class ECKeyPair implements Signing<ECDSASignature> {
 
 	@Override
 	public ECDSASignature sign(byte[] hash) {
-		return ECKeyUtils.keyHandler.sign(hash, privateKey, publicKey.decompressedBytes());
+		return ECKeyUtils.keyHandler.sign(hash, privateKey, publicKey.getBytes());
 	}
 
 	/**
@@ -151,7 +151,7 @@ public final class ECKeyPair implements Signing<ECDSASignature> {
 	 * @return An ECDSA Signature.
 	 */
 	public ECDSASignature sign(byte[] data, boolean enforceLowS, boolean beDeterministic) {
-		return ECKeyUtils.keyHandler.sign(data, privateKey, publicKey.decompressedBytes(), enforceLowS, beDeterministic);
+		return ECKeyUtils.keyHandler.sign(data, privateKey, publicKey.getBytes(), enforceLowS, beDeterministic);
 	}
 
 	@Override

--- a/radixdlt-java-common/src/main/java/com/radixdlt/crypto/ECKeyPair.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/crypto/ECKeyPair.java
@@ -70,7 +70,7 @@ public final class ECKeyPair implements Signing<ECDSASignature> {
 			ECPrivateKeyParameters privParams = (ECPrivateKeyParameters) keypair.getPrivate();
 			ECPublicKeyParameters pubParams = (ECPublicKeyParameters) keypair.getPublic();
 
-			final ECPublicKey publicKey = new ECPublicKey(pubParams.getQ());
+			final ECPublicKey publicKey = ECPublicKey.fromEcPoint(pubParams.getQ());
 			byte[] privateKeyBytes = ECKeyUtils.adjustArray(privParams.getD().toByteArray(), BYTES);
 			ECKeyUtils.validatePrivate(privateKeyBytes);
 

--- a/radixdlt-java-common/src/main/java/com/radixdlt/crypto/ECKeyUtils.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/crypto/ECKeyUtils.java
@@ -144,12 +144,12 @@ public class ECKeyUtils {
 		switch (pubkey0) {
 			case 2:
 			case 3:
-				if (publicKey.length != ECPublicKey.BYTES + 1) {
+				if (publicKey.length != ECPublicKey.COMPRESSED_BYTES) {
 					throw new PublicKeyException("Public key has invalid compressed size");
 				}
 				break;
 			case 4:
-				if (publicKey.length != (ECPublicKey.BYTES * 2) + 1) {
+				if (publicKey.length != ECPublicKey.UNCOMPRESSED_BYTES) {
 					throw new PublicKeyException("Public key has invalid uncompressed size");
 				}
 				break;

--- a/radixdlt-java-common/src/main/java/com/radixdlt/crypto/ECPublicKey.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/crypto/ECPublicKey.java
@@ -48,7 +48,7 @@ public final class ECPublicKey {
 	private final Supplier<EUID> uid;
 	private final int hashCode;
 
-	ECPublicKey(ECPoint ecPoint) {
+	private ECPublicKey(ECPoint ecPoint) {
 		this.ecPoint = Objects.requireNonNull(ecPoint);
 		this.uncompressedBytes = Suppliers.memoize(() -> this.ecPoint.getEncoded(false));
 		this.uid = Suppliers.memoize(this::computeUID);
@@ -57,6 +57,10 @@ public final class ECPublicKey {
 
 	private int computeHashCode() {
 		return Arrays.hashCode(uncompressedBytes.get());
+	}
+
+	public static ECPublicKey fromEcPoint(ECPoint ecPoint) {
+		return new ECPublicKey(ecPoint);
 	}
 
 	@JsonCreator

--- a/radixdlt-java-common/src/main/java/com/radixdlt/crypto/KeyHandler.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/crypto/KeyHandler.java
@@ -19,6 +19,7 @@ package com.radixdlt.crypto;
 
 import com.radixdlt.crypto.exception.PrivateKeyException;
 import com.radixdlt.crypto.exception.PublicKeyException;
+import org.bouncycastle.math.ec.ECPoint;
 
 /**
  * Interface for signature and public key computation functions.
@@ -50,11 +51,11 @@ interface KeyHandler {
 	 *
 	 * @param hash The hash to verify against
 	 * @param signature The signature to verify
-	 * @param publicKey The public key to verify the signature with
+	 * @param publicKeyPoint The public key point to verify the signature with
 	 *
 	 * @return An boolean indicating whether the signature could be successfully validated
 	 */
-	boolean verify(byte[] hash, ECDSASignature signature, byte[] publicKey);
+	boolean verify(byte[] hash, ECDSASignature signature, ECPoint publicKeyPoint);
 
 	/**
 	 * Compute a public key for the specified private key.

--- a/radixdlt-java-common/src/main/java/com/radixdlt/crypto/hdwallet/HDKeyPair.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/crypto/hdwallet/HDKeyPair.java
@@ -87,7 +87,7 @@ public final class HDKeyPair {
 
 	@VisibleForTesting
 	String publicKeyHex() {
-		return Bytes.toHexString(ecKeyPair.getPublicKey().getBytes());
+		return Bytes.toHexString(ecKeyPair.getPublicKey().getCompressedBytes());
 	}
 
 	@VisibleForTesting

--- a/radixdlt-java-common/src/main/java/com/radixdlt/identifiers/RadixAddress.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/identifiers/RadixAddress.java
@@ -56,7 +56,7 @@ public final class RadixAddress {
 	public RadixAddress(byte magic, ECPublicKey publicKey) {
 		this.publicKey = Objects.requireNonNull(publicKey);
 
-		byte[] digest = publicKey.getBytes();
+		byte[] digest = publicKey.getCompressedBytes();
 		byte[] addressBytes = new byte[1 + digest.length + 4];
 		addressBytes[0] = magic;
 		System.arraycopy(digest, 0, addressBytes, 1, digest.length);

--- a/radixdlt-java-common/src/test/java/com/radixdlt/crypto/ECDSASignatureTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/crypto/ECDSASignatureTest.java
@@ -124,7 +124,7 @@ public class ECDSASignatureTest {
 			var keyPair = ECKeyPair.fromPrivateKey(Bytes.fromHexString(vector.get("privateKey")));
 			var publicKey = keyPair.getPublicKey();
 
-			assertEquals(vector.get("expectedPublicKeyCompressed"), Bytes.toHexString(publicKey.getBytes()));
+			assertEquals(vector.get("expectedPublicKeyCompressed"), Bytes.toHexString(publicKey.getCompressedBytes()));
 
 			var messageUnhashedPlaintext = vector.get("message");
 			var messageUnhashed = messageUnhashedPlaintext.getBytes(StandardCharsets.UTF_8);

--- a/radixdlt-java-common/src/test/java/com/radixdlt/crypto/ECKeyUtilsTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/crypto/ECKeyUtilsTest.java
@@ -98,49 +98,49 @@ public class ECKeyUtilsTest {
 
 	@Test
 	public void testValidatePublicPassForType2Key() throws PublicKeyException {
-		var key = new byte[ECPublicKey.BYTES + 1];
+		var key = new byte[ECPublicKey.COMPRESSED_BYTES];
 		key[0] = 0x02;
 		ECKeyUtils.validatePublic(key);
 	}
 
 	@Test(expected = PublicKeyException.class)
 	public void testValidatePublicFailForType2Key() throws PublicKeyException {
-		var key = new byte[ECPublicKey.BYTES + 1 + 1];
+		var key = new byte[ECPublicKey.COMPRESSED_BYTES + 1];
 		key[0] = 0x02;
 		ECKeyUtils.validatePublic(key);
 	}
 
 	@Test
 	public void testValidatePublicPassForType3Key() throws PublicKeyException {
-		var key = new byte[ECPublicKey.BYTES + 1];
+		var key = new byte[ECPublicKey.COMPRESSED_BYTES];
 		key[0] = 0x03;
 		ECKeyUtils.validatePublic(key);
 	}
 
 	@Test(expected = PublicKeyException.class)
 	public void testValidatePublicFailForType3Key() throws PublicKeyException {
-		var key = new byte[ECPublicKey.BYTES + 1 + 1];
+		var key = new byte[ECPublicKey.COMPRESSED_BYTES + 1];
 		key[0] = 0x03;
 		ECKeyUtils.validatePublic(key);
 	}
 
 	@Test
 	public void testValidatePublicPassForType4Key() throws PublicKeyException {
-		var key = new byte[(ECPublicKey.BYTES * 2) + 1];
+		var key = new byte[ECPublicKey.UNCOMPRESSED_BYTES];
 		key[0] = 0x04;
 		ECKeyUtils.validatePublic(key);
 	}
 
 	@Test(expected = PublicKeyException.class)
 	public void testValidatePublicFailForType4Key() throws PublicKeyException {
-		var key = new byte[(ECPublicKey.BYTES * 2) + 1 + 1];
+		var key = new byte[ECPublicKey.UNCOMPRESSED_BYTES + 1];
 		key[0] = 0x04;
 		ECKeyUtils.validatePublic(key);
 	}
 
 	@Test(expected = PublicKeyException.class)
 	public void testValidatePublicFailForUnknownTypeKey() throws PublicKeyException {
-		var key = new byte[ECPublicKey.BYTES + 1];
+		var key = new byte[ECPublicKey.UNCOMPRESSED_BYTES];
 		key[0] = 0x05;
 		ECKeyUtils.validatePublic(key);
 	}

--- a/radixdlt-java-common/src/test/java/com/radixdlt/crypto/ECPublicKeyTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/crypto/ECPublicKeyTest.java
@@ -2,14 +2,19 @@ package com.radixdlt.crypto;
 
 import com.radixdlt.crypto.exception.PublicKeyException;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.bouncycastle.math.ec.ECPoint;
 import org.junit.Test;
 
 public class ECPublicKeyTest {
 	@Test
 	public void equalsContract() throws PublicKeyException {
+		final var p1 = ECKeyPair.generateNew().getPublicKey().getEcPoint();
+		final var p2 = ECKeyPair.generateNew().getPublicKey().getEcPoint();
 		ECPublicKey pk = ECPublicKey.fromBase64("AtuRjZPGw0b0BIYx46e0iKCaFU5EPnPx7/wLk6Vcursg");
 		EqualsVerifier.forClass(ECPublicKey.class)
-			.withIgnoredFields("uid") // cached value
+			.withNonnullFields("ecPoint", "uncompressedBytes")
+			.withIgnoredFields("uid", "ecPoint") // cached value
+			.withPrefabValues(ECPoint.class, p1, p2)
 			.withCachedHashCode("hashCode", "computeHashCode", pk)
 			.verify();
 	}

--- a/radixdlt-java-common/src/test/java/com/radixdlt/crypto/encryption/ECIESTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/crypto/encryption/ECIESTest.java
@@ -127,7 +127,7 @@ public class ECIESTest {
 		byte[] bytesToEncrypt = stringToEncrypt.getBytes(StandardCharsets.US_ASCII);
 		byte[] encrypted = ECIES.encrypt(
 			bytesToEncrypt,
-			this.testEncryptionKey.getPublicKey().getPublicPoint(),
+			this.testEncryptionKey.getPublicKey().getEcPoint(),
 			this.testEphemeralKey,
 			this.testIV
 		);

--- a/radixdlt-java-common/src/test/java/com/radixdlt/identifiers/RadixAddressTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/identifiers/RadixAddressTest.java
@@ -52,7 +52,7 @@ public class RadixAddressTest {
 
 	@Test
 	public void address_from_key_and_magical() throws PublicKeyException {
-		String publicKeyHexString = "03000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F";
+		String publicKeyHexString = "033fedae769522b862ad738874b6690ad78b166c6358cf20e316008465cb5f1562";
 		ECPublicKey key = ECPublicKey.fromBytes(Bytes.fromHexString(publicKeyHexString));
 		RadixAddress address = new RadixAddress((byte) 2, key);
 
@@ -61,7 +61,7 @@ public class RadixAddressTest {
 		// RadixStack/1_Subatomic/SubatomicModels/Address/AddressTests.swift
 		String expectedAddressHexString = "02" // magic byte
 				+ publicKeyHexString
-				+ "175341a9"; // checksum
+				+ "d1478c49"; // checksum
 
 		assertThat(expectedAddressHexString).isEqualToIgnoringCase(Bytes.toHexString(address.toByteArray()));
 	}


### PR DESCRIPTION
# Pull Request Template

## Title
Use uncompressed representation for ECPublicKey equality

## Description

Previously, if we initiated two instances of a public key of the same EC point with compressed and uncompressed byte representation (using `ECPublicKey.fromBytes`) we would end up with two unequal objects. This PR changes it so that they're equal. Precisely: two public keys are equal if their uncompressed byte representation is equal. It also adds a validation that the bytes passed actually represent a valid point. This change also revealed that some classes were implicitly relying and being given a key with compressed bytes representation (RadixAddress for example).
