### PR TITLE
Fix registration of JSON RPC methods

### DIFF
--- a/radixdlt-core/docker/Dockerfile.core
+++ b/radixdlt-core/docker/Dockerfile.core
@@ -20,7 +20,7 @@ ENV RADIXDLT_HOME=/home/radixdlt \
     RADIXDLT_DB_LOCATION=./RADIXDB \
     RADIXDLT_ENABLE_FAUCET=false \
     RADIXDLT_VALIDATOR_KEY_LOCATION=/home/radixdlt/node.ks \
-    RADIXDLT_ENABLE_CLIENT_API=false
+    RADIXDLT_ENABLE_CLIENT_API=true
 
 # install the radixdlt package
 COPY *.deb /tmp/

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/client/ClientApiModule.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/client/ClientApiModule.java
@@ -47,7 +47,7 @@ public class ClientApiModule extends AbstractModule {
 	}
 
 	@ProvidesIntoMap
-	@StringMapKey("radix.universeMagic")
+	@StringMapKey("radix.networkId")
 	public JsonRpcHandler universeMagicHandler(HighLevelApiHandler highLevelApiHandler) {
 		return highLevelApiHandler::handleUniverseMagic;
 	}

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/environment/rx/RxEnvironmentModule.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/environment/rx/RxEnvironmentModule.java
@@ -53,6 +53,7 @@ import com.radixdlt.epochs.EpochsLedgerUpdate;
 import com.radixdlt.ledger.LedgerUpdate;
 import com.radixdlt.mempool.MempoolAdd;
 import com.radixdlt.mempool.MempoolAddFailure;
+import com.radixdlt.mempool.MempoolAddSuccess;
 import com.radixdlt.mempool.MempoolRelayTrigger;
 import com.radixdlt.statecomputer.AtomsCommittedToLedger;
 import com.radixdlt.statecomputer.AtomsRemovedFromMempool;
@@ -89,6 +90,7 @@ public final class RxEnvironmentModule extends AbstractModule {
 		bind(Environment.class).to(RxEnvironment.class);
 		bind(ScheduledExecutorService.class).toInstance(ses);
 
+		bind(new TypeLiteral<Observable<MempoolAddSuccess>>() { }).toProvider(new ObservableProvider<>(MempoolAddSuccess.class));
 		bind(new TypeLiteral<Observable<MempoolAddFailure>>() { }).toProvider(new ObservableProvider<>(MempoolAddFailure.class));
 		bind(new TypeLiteral<Observable<MempoolRelayTrigger>>() { }).toProvider(new ObservableProvider<>(MempoolRelayTrigger.class));
 		bind(new TypeLiteral<Observable<ScheduledLocalTimeout>>() { }).toProvider(new ObservableProvider<>(ScheduledLocalTimeout.class));

--- a/radixdlt-core/radixdlt/src/main/java/org/radix/api/jsonrpc/RadixJsonRpcServer.java
+++ b/radixdlt-core/radixdlt/src/main/java/org/radix/api/jsonrpc/RadixJsonRpcServer.java
@@ -175,8 +175,6 @@ public final class RadixJsonRpcServer {
 		if (!request.has("method")) {
 			log.debug("RPC: error, no method");
 			return errorResponse(RpcError.INVALID_PARAMS, "method missing");
-		} else {
-			log.debug("RPC: methods {}", handlers.keySet());
 		}
 
 		try {

--- a/radixdlt-core/radixdlt/src/main/java/org/radix/api/jsonrpc/RadixJsonRpcServer.java
+++ b/radixdlt-core/radixdlt/src/main/java/org/radix/api/jsonrpc/RadixJsonRpcServer.java
@@ -114,6 +114,8 @@ public final class RadixJsonRpcServer {
 		handlers.put("Atoms.getAtomStatus", ledgerHandler::handleGetAtomStatus);
 
 		handlers.putAll(additionalHandlers);
+
+		handlers.keySet().forEach(name -> log.debug("Registered JSON RPC method: {}", name));
 	}
 
 	/**
@@ -173,6 +175,8 @@ public final class RadixJsonRpcServer {
 		if (!request.has("method")) {
 			log.debug("RPC: error, no method");
 			return errorResponse(RpcError.INVALID_PARAMS, "method missing");
+		} else {
+			log.debug("RPC: methods {}", handlers.keySet());
 		}
 
 		try {


### PR DESCRIPTION
Fixed registration of JSON RPC methods when high level API is enabled. 
Enabled client API by default when running docker container locally.
