### PR TITLE
Added option to issue default tokens on dev universe

### DIFF
--- a/radixdlt-core/radixdlt/build.gradle
+++ b/radixdlt-core/radixdlt/build.gradle
@@ -209,6 +209,7 @@ task generateDevUniverse(type: Exec) {
         "--enable-aws-secrets=${enableAWSSecret}",
         "--recreate-aws-secrets=${recreateAWSSecret}",
         "--network-name=${networkName}"
+        "--issue-default-tokens"
 }
 
 task generateJsonUniverse(type: Exec) {

--- a/radixdlt-core/radixdlt/build.gradle
+++ b/radixdlt-core/radixdlt/build.gradle
@@ -208,7 +208,7 @@ task generateDevUniverse(type: Exec) {
         "--helm-output-directory=${helmConfigOut}",
         "--enable-aws-secrets=${enableAWSSecret}",
         "--recreate-aws-secrets=${recreateAWSSecret}",
-        "--network-name=${networkName}"
+        "--network-name=${networkName}",
         "--issue-default-tokens"
 }
 


### PR DESCRIPTION





## Description
While generating dev universe, for testing purpose, it requires few of the accounts to have tokens issued. This is small change  in the gradle job to pass that option