### PR TITLE
Do not trigger workflows on every branch creation

### DIFF
--- a/.github/workflows/publish-jar-on-merge.yml
+++ b/.github/workflows/publish-jar-on-merge.yml
@@ -9,8 +9,8 @@ on:
       - rc\/*
       - release\/*
 jobs:
-  if: ${{ contains(github.ref, 'refs/heads/release/') }}
   cancel_running_workflows:
+    if: ${{ contains(github.ref, 'refs/heads/release/') }}
     name: Cancel running workflows
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/publish-jar-on-merge.yml
+++ b/.github/workflows/publish-jar-on-merge.yml
@@ -8,10 +8,9 @@ on:
     branches:
       - rc\/*
       - release\/*
-      - fix/artifact-distribution
 jobs:
   cancel_running_workflows:
-    if: ${{ contains(github.ref, 'refs/heads/release/') }} or ${{ contains(github.ref, 'refs/heads/fix/artifact-distribution') }}
+    if: ${{ contains(github.ref, 'refs/heads/release/') }} or ${{ contains(github.ref, 'refs/heads/rc') }}
     name: Cancel running workflows
     runs-on: ubuntu-20.04
     steps:
@@ -20,7 +19,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
   build:
-    if: ${{ contains(github.ref, 'refs/heads/release/') }}
+    if: ${{ contains(github.ref, 'refs/heads/release/') }} or ${{ contains(github.ref, 'refs/heads/rc') }}
     runs-on: ubuntu-latest
     name: Build JARs
     steps:
@@ -72,7 +71,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
   publish-jar:
-    if: ${{ contains(github.ref, 'refs/heads/release/') }}
+    if: ${{ contains(github.ref, 'refs/heads/release/') }} or ${{ contains(github.ref, 'refs/heads/rc') }}
     needs: build
     name: Publish JAR to Github package repository
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-jar-on-merge.yml
+++ b/.github/workflows/publish-jar-on-merge.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - rc\/*
       - release\/*
+      - fix/artifact-distribution
 jobs:
   cancel_running_workflows:
     if: ${{ contains(github.ref, 'refs/heads/release/') }}

--- a/.github/workflows/publish-jar-on-merge.yml
+++ b/.github/workflows/publish-jar-on-merge.yml
@@ -9,6 +9,7 @@ on:
       - rc\/*
       - release\/*
 jobs:
+  if: ${{ contains(github.ref, 'refs/heads/release/') }}
   cancel_running_workflows:
     name: Cancel running workflows
     runs-on: ubuntu-20.04
@@ -18,6 +19,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
   build:
+    if: ${{ contains(github.ref, 'refs/heads/release/') }}
     runs-on: ubuntu-latest
     name: Build JARs
     steps:
@@ -69,6 +71,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
   publish-jar:
+    if: ${{ contains(github.ref, 'refs/heads/release/') }}
     needs: build
     name: Publish JAR to Github package repository
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-jar-on-merge.yml
+++ b/.github/workflows/publish-jar-on-merge.yml
@@ -11,7 +11,7 @@ on:
       - fix/artifact-distribution
 jobs:
   cancel_running_workflows:
-    if: ${{ contains(github.ref, 'refs/heads/release/') }}
+    if: ${{ contains(github.ref, 'refs/heads/release/') }} or ${{ contains(github.ref, 'refs/heads/fix/artifact-distribution') }}
     name: Cancel running workflows
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/rc-publish-docker-on-merge.yml
+++ b/.github/workflows/rc-publish-docker-on-merge.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - rc\/*
-      - fix/artifact-distribution
 jobs:
   cancel_running_workflows:
     name: Cancel running workflows

--- a/.github/workflows/rc-publish-docker-on-merge.yml
+++ b/.github/workflows/rc-publish-docker-on-merge.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - rc\/*
+      - fix/artifact-distribution
 jobs:
   cancel_running_workflows:
     name: Cancel running workflows
@@ -31,12 +32,6 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: Build deb file
         run: |
-          if [[ "$GITHUB_REF" == *"refs/heads/release"* ]]; then
-              echo "Workflow triggered by on a release branch"
-          else
-            echo "Workflow triggered by on a rc branch"
-            export CI_VERSION=true
-          fi
           version=$(./gradlew radixCiVersion | grep radixdlt-version | cut -d: -f2)
           echo "Version: $version"
           cd radixdlt-core/radixdlt


### PR DESCRIPTION
Exclude jobs from running when non release or rc branches are created
Fix docker4deb step, as it needs to use a version that starts with a numeric value