### PR TITLE
Use strict check that the timeout event matches pending sync request

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/sync/LocalSyncService.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/sync/LocalSyncService.java
@@ -44,6 +44,7 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -81,6 +82,7 @@ public final class LocalSyncService {
 
 	private static final Logger log = LogManager.getLogger();
 
+	private final AtomicLong requestIdCounter = new AtomicLong();
 	private final RemoteEventDispatcher<StatusRequest> statusRequestDispatcher;
 	private final ScheduledEventDispatcher<SyncCheckReceiveStatusTimeout> syncCheckReceiveStatusTimeoutDispatcher;
 	private final RemoteEventDispatcher<SyncRequest> syncRequestDispatcher;
@@ -329,13 +331,14 @@ public final class LocalSyncService {
 
 		final var currentHeader = currentState.getCurrentHeader();
 
+		final var requestId = requestIdCounter.incrementAndGet();
 		this.syncRequestDispatcher.dispatch(peer, SyncRequest.create(currentHeader.toDto()));
 		this.syncRequestTimeoutDispatcher.dispatch(
-			SyncRequestTimeout.create(peer, currentHeader),
+			SyncRequestTimeout.create(peer, requestId),
 			this.syncConfig.syncRequestTimeout()
 		);
 
-		return currentState.withWaitingFor(peer);
+		return currentState.withPendingRequest(peer, requestId);
 	}
 
 	private boolean isFullySynced(SyncState.SyncingState syncingState) {
@@ -359,7 +362,7 @@ public final class LocalSyncService {
 			// didn't receive any commands, remove from candidate peers and processSync
 			return this.processSync(
 				currentState
-					.clearWaitingFor()
+					.clearPendingRequest()
 					.removeCandidate(sender)
 			);
 		} else if (!this.verifyResponse(syncResponse)) {
@@ -369,7 +372,7 @@ public final class LocalSyncService {
 			invalidSyncedCommandsSender.sendInvalidSyncResponse(syncResponse);
 			return this.processSync(
 				currentState
-					.clearWaitingFor()
+					.clearPendingRequest()
 					.removeCandidate(sender)
 			);
 		} else {
@@ -378,7 +381,7 @@ public final class LocalSyncService {
 				500L
 			);
 			this.verifiedSender.sendVerifiedSyncResponse(syncResponse);
-			return currentState.clearWaitingFor();
+			return currentState.clearPendingRequest();
 		}
 	}
 
@@ -409,8 +412,12 @@ public final class LocalSyncService {
 	}
 
 	private SyncState processSyncRequestTimeout(SyncingState currentState, SyncRequestTimeout syncRequestTimeout) {
-		if (!currentState.waitingForResponseFrom(syncRequestTimeout.getPeer())
-			|| !currentState.getCurrentHeader().equals(syncRequestTimeout.getCurrentHeader())) {
+		final var timeoutMatchesRequest = currentState.getPendingRequest().stream()
+			.anyMatch(pr -> pr.getRequestId() == syncRequestTimeout.getRequestId()
+				&& pr.getPeer().equals(syncRequestTimeout.getPeer())
+			);
+
+		if (!timeoutMatchesRequest) {
 			return currentState; // ignore, this timeout is no longer valid
 		}
 
@@ -418,7 +425,7 @@ public final class LocalSyncService {
 
 		return this.processSync(
 			currentState
-				.clearWaitingFor()
+				.clearPendingRequest()
 				.removeCandidate(syncRequestTimeout.getPeer())
 		);
 	}

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/sync/messages/local/SyncRequestTimeout.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/sync/messages/local/SyncRequestTimeout.java
@@ -17,7 +17,6 @@
 
 package com.radixdlt.sync.messages.local;
 
-import com.radixdlt.consensus.LedgerProof;
 import com.radixdlt.consensus.bft.BFTNode;
 
 import java.util.Objects;
@@ -28,28 +27,29 @@ import java.util.Objects;
 public final class SyncRequestTimeout {
 
 	private final BFTNode peer;
-	private final LedgerProof currentHeader;
+	private final long requestId;
 
-	public static SyncRequestTimeout create(BFTNode peer, LedgerProof currentHeader) {
-		return new SyncRequestTimeout(peer, currentHeader);
+	public static SyncRequestTimeout create(BFTNode peer, long requestId) {
+		return new SyncRequestTimeout(peer, requestId);
 	}
 
-	private SyncRequestTimeout(BFTNode peer, LedgerProof currentHeader) {
+	private SyncRequestTimeout(BFTNode peer, long requestId) {
 		this.peer = peer;
-		this.currentHeader = currentHeader;
+		this.requestId = requestId;
 	}
 
 	public BFTNode getPeer() {
 		return peer;
 	}
 
-	public LedgerProof getCurrentHeader() {
-		return currentHeader;
+	public long getRequestId() {
+		return requestId;
 	}
 
 	@Override
 	public String toString() {
-		return String.format("%s{peer=%s currentHeader=%s}", this.getClass().getSimpleName(), peer, currentHeader);
+		return String.format("%s{peer=%s requestId=%s}",
+			this.getClass().getSimpleName(), peer, requestId);
 	}
 
 	@Override
@@ -61,11 +61,12 @@ public final class SyncRequestTimeout {
 			return false;
 		}
 		SyncRequestTimeout that = (SyncRequestTimeout) o;
-		return Objects.equals(peer, that.peer) && Objects.equals(currentHeader, that.currentHeader);
+		return Objects.equals(peer, that.peer)
+			&& requestId == that.requestId;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(peer, currentHeader);
+		return Objects.hash(peer, requestId);
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sync/SyncStateTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sync/SyncStateTest.java
@@ -123,12 +123,12 @@ public class SyncStateTest {
         assertFalse(initialState.waitingForResponse());
 
         final var peer = mock(BFTNode.class);
-        final var newState = initialState.withWaitingFor(peer);
+        final var newState = initialState.withPendingRequest(peer, 1L);
 
         assertTrue(newState.waitingForResponse());
         assertTrue(newState.waitingForResponseFrom(peer));
 
-        assertFalse(newState.clearWaitingFor().waitingForResponse());
+        assertFalse(newState.clearPendingRequest().waitingForResponse());
     }
 
     @Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sync/SyncStateTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/sync/SyncStateTest.java
@@ -39,12 +39,16 @@ public class SyncStateTest {
             .verify();
 
         EqualsVerifier.forClass(SyncState.SyncCheckState.class)
-                .withPrefabValues(HashCode.class, HashUtils.random256(), HashUtils.random256())
-                .verify();
+            .withPrefabValues(HashCode.class, HashUtils.random256(), HashUtils.random256())
+            .verify();
 
         EqualsVerifier.forClass(SyncState.SyncingState.class)
-                .withPrefabValues(HashCode.class, HashUtils.random256(), HashUtils.random256())
-                .verify();
+            .withPrefabValues(HashCode.class, HashUtils.random256(), HashUtils.random256())
+            .verify();
+
+        EqualsVerifier.forClass(SyncState.PendingRequest.class)
+            .withPrefabValues(HashCode.class, HashUtils.random256(), HashUtils.random256())
+            .verify();
     }
 
     @Test


### PR DESCRIPTION
# Pull Request Template

## Title
Use strict check that the timeout event matches pending sync request

## Description
Previously we used to rely on a ledger header to match timeout event to the request, but this may not always be accurate (if two request for the same header have been sent). This changes it so that a strict (ID-based) matching is used.