### PR TITLE
Task/rpnv1 1261 docker permission issue

### DIFF
--- a/radixdlt-core/docker/Dockerfile.core
+++ b/radixdlt-core/docker/Dockerfile.core
@@ -31,3 +31,8 @@ COPY scripts/config_radixdlt.sh /opt/radixdlt/config_radixdlt.sh
 # copy configuration templates
 WORKDIR /home/radixdlt
 COPY config/ /home/radixdlt/
+
+# Add healthcheck
+COPY scripts/docker-healthcheck.sh /home/radixdlt/
+HEALTHCHECK CMD sh /home/radixdlt/docker-healthcheck.sh
+RUN chmod +x /home/radixdlt/docker-healthcheck.sh

--- a/radixdlt-core/docker/Dockerfile.core
+++ b/radixdlt-core/docker/Dockerfile.core
@@ -31,4 +31,3 @@ COPY scripts/config_radixdlt.sh /opt/radixdlt/config_radixdlt.sh
 # copy configuration templates
 WORKDIR /home/radixdlt
 COPY config/ /home/radixdlt/
-RUN chown -R radixdlt:radixdlt /home/radixdlt/

--- a/radixdlt-core/docker/scripts/config_radixdlt.sh
+++ b/radixdlt-core/docker/scripts/config_radixdlt.sh
@@ -5,6 +5,14 @@ set -ex
 # need this to run on Alpine (grsec) kernels without crashing
 find /usr -type f -name java -exec setfattr -n user.pax.flags -v em {} \;
 
+#Add user using env variable if provided
+USER_ID=${LOCAL_USER_ID:-999}
+USER_NAME=radixdlt
+# check and delete the user that is created in postinstal action of deb package
+getent group $USER_NAME >/dev/null && groupmod -g $USER_ID radixdlt || groupadd -r $USER_NAME
+getent passwd $RADIXDLT_USER >/dev/null && usermod -u $USER_ID radixdlt || useradd -r -d "$RADIXDLT_HOME" -g $RADIXDLT_USER $RADIXDLT_USER
+chown -R radixdlt:radixdlt /home/radixdlt/
+
 env | sort
 
 envsubst <"${RADIXDLT_HOME:?}"/default.config.envsubst >"${RADIXDLT_HOME:?}"/default.config

--- a/radixdlt-core/docker/scripts/docker-healthcheck.sh
+++ b/radixdlt-core/docker/scripts/docker-healthcheck.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+# API is the last to come up when starting and node endpoint is always enabled on docker
+exec curl http://$HOSTNAME:$RADIXDLT_NODE_API_PORT/node >/dev/null

--- a/radixdlt-core/docker/scripts/docker-healthcheck.sh
+++ b/radixdlt-core/docker/scripts/docker-healthcheck.sh
@@ -3,4 +3,4 @@
 set -e
 
 # API is the last to come up when starting and node endpoint is always enabled on docker
-exec curl http://$HOSTNAME:$RADIXDLT_NODE_API_PORT/node >/dev/null
+exec curl http://$HOSTNAME:$RADIXDLT_NODE_API_PORT/node >/dev/null && netstat -ltn | grep -c 30000


### PR DESCRIPTION

Add healthcheck to docker image
Update user radixdlt to have a Uid using env variable or a default value


## Description

Providing the uId using environment variable allows to bind mount ledger folder with restricted permissions. Docker level heathcheck provides right status on container if there are exceptions at the start of container and process isn't starting up