### PR TITLE
Fix memleak in local sync

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/sync/SyncState.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/sync/SyncState.java
@@ -281,10 +281,12 @@ public interface SyncState {
 		public SyncingState withCandidatePeers(ImmutableList<BFTNode> peers) {
 			return new SyncingState(
 				currentHeader,
-				new ImmutableList.Builder<BFTNode>()
-					.addAll(peers)
-					.addAll(candidatePeers)
-					.build(),
+					ImmutableSet.copyOf(
+						new ImmutableList.Builder<BFTNode>()
+						.addAll(peers)
+						.addAll(candidatePeers)
+						.build()
+					).asList(),
 				targetHeader,
 				pendingRequest
 			);


### PR DESCRIPTION
# Pull Request Template

## Title

Fix memleak in local sync

## Description

This fixes a memory leak in ledger sync. A list of candidate peers for sync wasn't being checked for duplicate elements and it just kept adding to it.
