### PR TITLE
Flatten finalize_transaction parameters and other fixes

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/ValidatorInfoDetails.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/ValidatorInfoDetails.java
@@ -17,11 +17,11 @@
 
 package com.radixdlt.api.data;
 
+import org.json.JSONObject;
+
 import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.identifiers.REAddr;
 import com.radixdlt.networks.Addressing;
-import org.json.JSONObject;
-
 import com.radixdlt.statecomputer.ValidatorDetails;
 import com.radixdlt.utils.UInt256;
 
@@ -150,7 +150,7 @@ public class ValidatorInfoDetails {
 			.put("infoURL", infoUrl)
 			.put("totalDelegatedStake", totalStake)
 			.put("ownerDelegation", ownerStake)
-			.put("rakePercentage", percentage)
+			.put("validatorFee", percentage)
 			.put("registered", registered)
 			.put("isExternalStakeAccepted", externalStakesAllowed);
 	}

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/handler/ConstructionHandler.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/handler/ConstructionHandler.java
@@ -43,7 +43,6 @@ import static com.radixdlt.api.JsonRpcUtil.jsonObject;
 import static com.radixdlt.api.JsonRpcUtil.optString;
 import static com.radixdlt.api.JsonRpcUtil.safeArray;
 import static com.radixdlt.api.JsonRpcUtil.safeBlob;
-import static com.radixdlt.api.JsonRpcUtil.safeObject;
 import static com.radixdlt.api.JsonRpcUtil.safeString;
 import static com.radixdlt.api.JsonRpcUtil.withRequiredParameters;
 import static com.radixdlt.api.data.ApiErrors.INVALID_SIGNATURE_DER;
@@ -91,7 +90,7 @@ public class ConstructionHandler {
 	public JSONObject handleConstructionFinalizeTransaction(JSONObject request) {
 		return withRequiredParameters(
 			request,
-			List.of("transaction", "signatureDER", "publicKeyOfSigner"),
+			List.of("blob", "signatureDER", "publicKeyOfSigner"),
 			List.of("immediateSubmit"),
 			params ->
 				allOf(parseBlob(params), parseSignatureDer(params), parsePublicKey(params))
@@ -122,8 +121,7 @@ public class ConstructionHandler {
 	}
 
 	private static Result<byte[]> parseBlob(JSONObject params) {
-		return safeObject(params, "transaction")
-			.flatMap(txObj -> safeBlob(txObj, "blob"));
+		return safeBlob(params, "blob");
 	}
 
 	private static Result<ECDSASignature> parseSignatureDer(JSONObject params) {

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/AccountInfoService.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/AccountInfoService.java
@@ -17,7 +17,6 @@
 
 package com.radixdlt.api.service;
 
-import com.radixdlt.networks.Addressing;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -30,6 +29,7 @@ import com.radixdlt.consensus.bft.Self;
 import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.engine.RadixEngine;
 import com.radixdlt.identifiers.REAddr;
+import com.radixdlt.networks.Addressing;
 import com.radixdlt.statecomputer.LedgerAndBFTProof;
 import com.radixdlt.utils.Pair;
 import com.radixdlt.utils.UInt256;
@@ -81,14 +81,14 @@ public class AccountInfoService {
 				.put("url", details.getInfoUrl())
 				.put("registered", details.isRegistered())
 				.put("owner", addressing.forAccounts().of(details.getOwner()))
-				.put("rakePercentage", details.getPercentage())
+				.put("validatorFee", details.getPercentage())
 				.put("allowDelegation", details.isExternalStakesAllowed()),
 			() -> result
 				.put("name", "")
 				.put("url", "")
 				.put("registered", false)
 				.put("owner", addressing.forAccounts().of(REAddr.ofPubKeyAccount(bftKey)))
-				.put("rakePercentage", 0)
+				.put("validatorFee", 0)
 				.put("allowDelegation", true)
 		);
 

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/ActionParserService.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/ActionParserService.java
@@ -17,7 +17,6 @@
 
 package com.radixdlt.api.service;
 
-import com.radixdlt.networks.Addressing;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -26,6 +25,7 @@ import com.radixdlt.api.data.ActionType;
 import com.radixdlt.api.data.action.TransactionAction;
 import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.identifiers.REAddr;
+import com.radixdlt.networks.Addressing;
 import com.radixdlt.utils.UInt256;
 import com.radixdlt.utils.functional.Result;
 
@@ -187,7 +187,7 @@ public final class ActionParserService {
 	}
 
 	private Result<Integer> percentage(JSONObject element) {
-		return param(element, "rakePercentage")
+		return param(element, "validatorFee")
 			.flatMap(parameter -> wrap(UNABLE_TO_DECODE, () -> Integer.parseInt(parameter)));
 	}
 

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/api/handler/ConstructionHandlerTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/api/handler/ConstructionHandlerTest.java
@@ -130,16 +130,10 @@ public class ConstructionHandlerTest {
 
 		var blob = randomBytes();
 		var hash = HashUtils.sha256(blob).asBytes();
-
-		var transaction = jsonObject()
-			.put("blob", Hex.toHexString(blob))
-			.put("hashOfBlobToSign", Hex.toHexString(hash));
-
 		var keyPair = ECKeyPair.generateNew();
-
 		var signature = keyPair.sign(hash);
 		var params = jsonArray()
-			.put(transaction)
+			.put(Hex.toHexString(blob))
 			.put(encodeToDer(signature))
 			.put(keyPair.getPublicKey().toHex());
 
@@ -166,16 +160,10 @@ public class ConstructionHandlerTest {
 
 		var blob = randomBytes();
 		var hash = HashUtils.sha256(blob).asBytes();
-
-		var transaction = jsonObject()
-			.put("blob", Hex.toHexString(blob))
-			.put("hashOfBlobToSign", Hex.toHexString(hash));
-
 		var keyPair = ECKeyPair.generateNew();
-
 		var signature = keyPair.sign(hash);
 		var params = jsonObject()
-			.put("transaction", transaction)
+			.put("blob", Hex.toHexString(blob))
 			.put("signatureDER", encodeToDer(signature))
 			.put("publicKeyOfSigner", keyPair.getPublicKey().toHex());
 

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/async/AsyncRadixApi.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/async/AsyncRadixApi.java
@@ -213,7 +213,10 @@ public class AsyncRadixApi implements RadixApi {
 		@Override
 		public Promise<TxBlobDTO> finalize(FinalizedTransaction request, boolean immediateSubmit) {
 			return call(
-				request(CONSTRUCTION_FINALIZE, request.getBlob(), request.getSignature(), request.getPublicKey(), Boolean.toString(immediateSubmit)),
+				request(
+					CONSTRUCTION_FINALIZE,
+					Hex.toHexString(request.getRawBlob()), request.getSignature(), request.getPublicKey(), Boolean.toString(immediateSubmit)
+				),
 				new TypeReference<>() {}
 			);
 		}
@@ -554,7 +557,6 @@ public class AsyncRadixApi implements RadixApi {
 				}
 
 				public void checkClientTrusted(X509Certificate[] certs, String authType) { }
-
 				public void checkServerTrusted(X509Certificate[] certs, String authType) { }
 			}
 		};

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/sync/RadixApi.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/sync/RadixApi.java
@@ -57,6 +57,7 @@ import com.radixdlt.client.lib.dto.ValidatorsResponse;
 import com.radixdlt.identifiers.AID;
 import com.radixdlt.utils.functional.Result;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
@@ -73,6 +74,8 @@ public interface RadixApi {
 	}
 
 	RadixApi withTrace();
+
+	RadixApi withTimeout(Duration timeout);
 
 	interface Network {
 		Result<NetworkId> id();

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/dto/LocalValidatorInfo.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/dto/LocalValidatorInfo.java
@@ -68,7 +68,7 @@ public class LocalValidatorInfo {
 		@JsonProperty(value = "registered", required = true) boolean registered,
 		@JsonProperty(value = "stakes", required = true) List<DelegatedStake> stakes,
 		@JsonProperty(value = "owner", required = true) AccountAddress owner,
-		@JsonProperty(value = "rakePercentage", required = true) int rakePercentage,
+		@JsonProperty(value = "validatorFee", required = true) int rakePercentage,
 		@JsonProperty(value = "allowDelegation", required = true) boolean allowDelegation
 	) {
 		return new LocalValidatorInfo(address, totalStake, name, url, registered, stakes, owner, rakePercentage, allowDelegation);

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/dto/ValidatorDTO.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/dto/ValidatorDTO.java
@@ -66,7 +66,7 @@ public class ValidatorDTO {
 		@JsonProperty(value = "infoURL", required = true) String infoURL,
 		@JsonProperty(value = "totalDelegatedStake", required = true) UInt256 totalDelegatedStake,
 		@JsonProperty(value = "ownerDelegation", required = true) UInt256 ownerDelegation,
-		@JsonProperty(value = "rakePercentage", required = true) long percentage,
+		@JsonProperty(value = "validatorFee", required = true) long percentage,
 		@JsonProperty(value = "isExternalStakeAccepted", required = true) boolean isExternalStakeAccepted,
 		@JsonProperty(value = "registered", required = true) boolean registered
 	) {

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/network/HttpClients.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/network/HttpClients.java
@@ -22,19 +22,21 @@
 
 package com.radixdlt.client.lib.network;
 
-import io.reactivex.Single;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
+
+import io.reactivex.Single;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import okhttp3.OkHttpClient;
 
+@Deprecated	//TODO: remove it before mainnet
 public class HttpClients {
 	private HttpClients() {
 	}
@@ -103,6 +105,7 @@ public class HttpClients {
 	 *
 	 * @return created client
 	 */
+	@Deprecated
 	public static OkHttpClient getSslAllTrustingClient() {
 		synchronized (LOCK) {
 			if (sslAllTrustingClient == null) {
@@ -111,5 +114,4 @@ public class HttpClients {
 			return sslAllTrustingClient;
 		}
 	}
-
 }

--- a/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/async/AsyncRadixApiLocalTest.java
+++ b/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/async/AsyncRadixApiLocalTest.java
@@ -60,15 +60,15 @@ public class AsyncRadixApiLocalTest {
 		+ "tt0q0sjsjwawyvs6zsklj\",\"amount\":\"1000000000000000000000000000\"}],\"tokens\":[]}},\"id\":\"2\",\"jsonrp"
 		+ "c\":\"2.0\"}\n";
 	private static final String VALIDATOR_INFO = "{\"result\":{\"owner\":\"ddx1qsprpeqt46q3qqmx56muck5rs9dhuz9a2x9l0g4"
-		+ "addup7z2zfm4c3jqurkgjv\",\"rakePercentage\":0,\"address\":\"dv1qgcwgzawsygqxe4xklx94quptdlq302330m690tt0q0s"
+		+ "addup7z2zfm4c3jqurkgjv\",\"validatorFee\":0,\"address\":\"dv1qgcwgzawsygqxe4xklx94quptdlq302330m690tt0q0s"
 		+ "jsjwawyvs6zsklj\",\"stakes\":[{\"amount\":\"1000000000000000000000000000\",\"delegator\":\"ddx1qsprpeqt46q3"
 		+ "qqmx56muck5rs9dhuz9a2x9l0g4addup7z2zfm4c3jqurkgjv\"}],\"allowDelegation\":true,\"name\":\"\",\"registered\""
 		+ ":true,\"totalStake\":\"1000000000000000000000000000\",\"url\":\"\"},\"id\":\"2\",\"jsonrpc\":\"2.0\"}\n";
 	private static final String NEXT_EPOCH = "{\"result\":{\"validators\":[{\"totalDelegatedStake\":\"1000000000000000"
-		+ "000000000000\",\"rakePercentage\":0,\"address\":\"dv1qtjlayqkvk234cwh5rs72uunjwgte8gnr4gp6vvgqmmdjl9fjvr5ul"
+		+ "000000000000\",\"validatorFee\":0,\"address\":\"dv1qtjlayqkvk234cwh5rs72uunjwgte8gnr4gp6vvgqmmdjl9fjvr5ul"
 		+ "nv4zg\",\"infoURL\":\"\",\"ownerDelegation\":\"1000000000000000000000000000\",\"name\":\"\",\"registered\":"
 		+ "true,\"ownerAddress\":\"ddx1qspwtl5szeje2xhp67swretnjwfep0yazvw4q8f33qr0dktu4xfswnsjjpvcy\",\"isExternalSta"
-		+ "keAccepted\":true},{\"totalDelegatedStake\":\"1000000000000000000000000000\",\"rakePercentage\":0,\"address"
+		+ "keAccepted\":true},{\"totalDelegatedStake\":\"1000000000000000000000000000\",\"validatorFee\":0,\"address"
 		+ "\":\"dv1qgcwgzawsygqxe4xklx94quptdlq302330m690tt0q0sjsjwawyvs6zsklj\",\"infoURL\":\"\",\"ownerDelegation\":"
 		+ "\"1000000000000000000000000000\",\"name\":\"\",\"registered\":true,\"ownerAddress\":\"ddx1qsprpeqt46q3qqmx5"
 		+ "6muck5rs9dhuz9a2x9l0g4addup7z2zfm4c3jqurkgjv\",\"isExternalStakeAccepted\":true}]},\"id\":\"2\",\"jsonrpc\""

--- a/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/async/AsyncRadixApiValidatorTest.java
+++ b/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/async/AsyncRadixApiValidatorTest.java
@@ -40,15 +40,15 @@ public class AsyncRadixApiValidatorTest {
 
 	private static final String NETWORK_ID = "{\"result\":{\"networkId\":99},\"id\":\"1\",\"jsonrpc\":\"2.0\"}";
 	private static final String LIST = "{\"result\":{\"cursor\":\"dv1q0llj774w40wafpqg5apgd2jxhfc9aj897zk3gvt9uzh59rq9964vjryzf9\""
-		+ ",\"validators\":[{\"totalDelegatedStake\":\"100000000000000000000\",\"rakePercentage\":0,\"address\":\"dv1qfwtmurydewmf"
+		+ ",\"validators\":[{\"totalDelegatedStake\":\"100000000000000000000\",\"validatorFee\":0,\"address\":\"dv1qfwtmurydewmf"
 		+ "64rnrektuh20g8r6svm0cpnpcuuay4ammw2cnumc3jtmxl\",\"infoURL\":\"\",\"ownerDelegation\":\"100000000000000000000\",\"name\""
 		+ ":\"\",\"registered\":true,\"ownerAddress\":\"ddx1qsp9e00sv3h9md825wv0xe0jafaqu02pndlqxv8rnn5jhh0detz0n0qtp2phh\",\"isExt"
-		+ "ernalStakeAccepted\":true},{\"totalDelegatedStake\":\"100000000000000000000\",\"rakePercentage\":0,\"address\":\"dv1q0ll"
+		+ "ernalStakeAccepted\":true},{\"totalDelegatedStake\":\"100000000000000000000\",\"validatorFee\":0,\"address\":\"dv1q0ll"
 		+ "j774w40wafpqg5apgd2jxhfc9aj897zk3gvt9uzh59rq9964vjryzf9\",\"infoURL\":\"\",\"ownerDelegation\":\"100000000000000000000\""
 		+ ",\"name\":\"\",\"registered\":true,\"ownerAddress\":\"ddx1qspll7tm6464am4yypzn59p42g6a8qhkguhc269p3vhs27s5vq5h24sfvvdfj\""
 		+ ",\"isExternalStakeAccepted\":true}]},\"id\":\"2\",\"jsonrpc\":\"2.0\"}\n";
 
-	private static final String LOOKUP = "{\"result\":{\"totalDelegatedStake\":\"4754240000000000000000000\",\"rakePercentage\":0,\""
+	private static final String LOOKUP = "{\"result\":{\"totalDelegatedStake\":\"4754240000000000000000000\",\"validatorFee\":0,\""
 		+ "address\":\"dv1q0llj774w40wafpqg5apgd2jxhfc9aj897zk3gvt9uzh59rq9964vjryzf9\",\"infoURL\":\"\",\"ownerDelegation\":\"10000"
 		+ "0000000000000000\",\"name\":\"\",\"registered\":true,\"ownerAddress\":\"ddx1qspll7tm6464am4yypzn59p42g6a8qhkguhc269p3vhs2"
 		+ "7s5vq5h24sfvvdfj\",\"isExternalStakeAccepted\":true},\"id\":\"2\",\"jsonrpc\":\"2.0\"}\n";

--- a/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiConsensusTest.java
+++ b/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiConsensusTest.java
@@ -20,21 +20,14 @@ import org.junit.Test;
 
 import com.radixdlt.utils.functional.Result;
 
-import java.io.IOException;
-
-import okhttp3.Call;
-import okhttp3.OkHttpClient;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import static com.radixdlt.client.lib.api.sync.RadixApi.DEFAULT_PRIMARY_PORT;
-import static com.radixdlt.client.lib.api.sync.RadixApi.DEFAULT_SECONDARY_PORT;
 
 public class SyncRadixApiConsensusTest {
 	private static final String BASE_URL = "http://localhost/";
@@ -48,10 +41,10 @@ public class SyncRadixApiConsensusTest {
 		+ "0,\"consensusEvents\":319926,\"indirectParent\":1,\"proposalsMade\":79981},\"id\":\"2\",\"jsonrpc\":"
 		+ "\"2.0\"}\n";
 
-	private final OkHttpClient client = mock(OkHttpClient.class);
+	private final HttpClient client = mock(HttpClient.class);
 
 	@Test
-	public void testConfiguration() throws IOException {
+	public void testConfiguration() throws Exception {
 		prepareClient(CONFIGURATION)
 			.map(RadixApi::withTrace)
 			.onFailure(failure -> fail(failure.toString()))
@@ -62,7 +55,7 @@ public class SyncRadixApiConsensusTest {
 	}
 
 	@Test
-	public void testData() throws IOException {
+	public void testData() throws Exception {
 		prepareClient(DATA)
 			.map(RadixApi::withTrace)
 			.onFailure(failure -> fail(failure.toString()))
@@ -73,16 +66,13 @@ public class SyncRadixApiConsensusTest {
 					.onSuccess(data -> assertEquals(159960L, data.getStateVersion())));
 	}
 
-	private Result<RadixApi> prepareClient(String responseBody) throws IOException {
-		var call = mock(Call.class);
-		var response = mock(Response.class);
-		var body = mock(ResponseBody.class);
+	private Result<RadixApi> prepareClient(String responseBody) throws Exception {
+		@SuppressWarnings("unchecked")
+		var response = (HttpResponse<String>) mock(HttpResponse.class);
 
-		when(client.newCall(any())).thenReturn(call);
-		when(call.execute()).thenReturn(response);
-		when(response.body()).thenReturn(body);
-		when(body.string()).thenReturn(NETWORK_ID, responseBody);
+		when(response.body()).thenReturn(NETWORK_ID, responseBody);
+		when(client.<String>send(any(), any())).thenReturn(response);
 
-		return SyncRadixApi.connect(BASE_URL, DEFAULT_PRIMARY_PORT, DEFAULT_SECONDARY_PORT, client);
+		return SyncRadixApi.connect(BASE_URL, RadixApi.DEFAULT_PRIMARY_PORT, RadixApi.DEFAULT_SECONDARY_PORT, client);
 	}
 }

--- a/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiLedgerTest.java
+++ b/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiLedgerTest.java
@@ -20,21 +20,14 @@ import org.junit.Test;
 
 import com.radixdlt.utils.functional.Result;
 
-import java.io.IOException;
-
-import okhttp3.Call;
-import okhttp3.OkHttpClient;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import static com.radixdlt.client.lib.api.sync.RadixApi.DEFAULT_PRIMARY_PORT;
-import static com.radixdlt.client.lib.api.sync.RadixApi.DEFAULT_SECONDARY_PORT;
 
 public class SyncRadixApiLedgerTest {
 	private static final String BASE_URL = "http://localhost/";
@@ -110,10 +103,10 @@ public class SyncRadixApiLedgerTest {
 		+ "or\":\"7d773d192544808ba16a047781ae06ce3cb140d65bb757439947de81aea8422b\",\"version\":1,\"timestamp"
 		+ "\":0}}},\"id\":\"2\",\"jsonrpc\":\"2.0\"}\n";
 
-	private final OkHttpClient client = mock(OkHttpClient.class);
+	private final HttpClient client = mock(HttpClient.class);
 
 	@Test
-	public void testLatest() throws IOException {
+	public void testLatest() throws Exception {
 		prepareClient(LATEST)
 			.map(RadixApi::withTrace)
 			.onFailure(failure -> fail(failure.toString()))
@@ -126,7 +119,7 @@ public class SyncRadixApiLedgerTest {
 	}
 
 	@Test
-	public void testEpoch() throws IOException {
+	public void testEpoch() throws Exception {
 		prepareClient(EPOCH)
 			.map(RadixApi::withTrace)
 			.onFailure(failure -> fail(failure.toString()))
@@ -140,7 +133,7 @@ public class SyncRadixApiLedgerTest {
 	}
 
 	@Test
-	public void testCheckpoints() throws IOException {
+	public void testCheckpoints() throws Exception {
 		prepareClient(CHECKPOINTS)
 			.map(RadixApi::withTrace)
 			.onFailure(failure -> fail(failure.toString()))
@@ -150,16 +143,13 @@ public class SyncRadixApiLedgerTest {
 				.onSuccess(checkpoint -> assertEquals(2, checkpoint.getProof().getHeader().getNextValidators().size())));
 	}
 
-	private Result<RadixApi> prepareClient(String responseBody) throws IOException {
-		var call = mock(Call.class);
-		var response = mock(Response.class);
-		var body = mock(ResponseBody.class);
+	private Result<RadixApi> prepareClient(String responseBody) throws Exception {
+		@SuppressWarnings("unchecked")
+		var response = (HttpResponse<String>) mock(HttpResponse.class);
 
-		when(client.newCall(any())).thenReturn(call);
-		when(call.execute()).thenReturn(response);
-		when(response.body()).thenReturn(body);
-		when(body.string()).thenReturn(NETWORK_ID, responseBody);
+		when(response.body()).thenReturn(NETWORK_ID, responseBody);
+		when(client.<String>send(any(), any())).thenReturn(response);
 
-		return SyncRadixApi.connect(BASE_URL, DEFAULT_PRIMARY_PORT, DEFAULT_SECONDARY_PORT, client);
+		return SyncRadixApi.connect(BASE_URL, RadixApi.DEFAULT_PRIMARY_PORT, RadixApi.DEFAULT_SECONDARY_PORT, client);
 	}
 }

--- a/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiMempoolTest.java
+++ b/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiMempoolTest.java
@@ -20,21 +20,14 @@ import org.junit.Test;
 
 import com.radixdlt.utils.functional.Result;
 
-import java.io.IOException;
-
-import okhttp3.Call;
-import okhttp3.OkHttpClient;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import static com.radixdlt.client.lib.api.sync.RadixApi.DEFAULT_PRIMARY_PORT;
-import static com.radixdlt.client.lib.api.sync.RadixApi.DEFAULT_SECONDARY_PORT;
 
 public class SyncRadixApiMempoolTest {
 	private static final String BASE_URL = "http://localhost/";
@@ -46,10 +39,10 @@ public class SyncRadixApiMempoolTest {
 		+ "\"proposedTransaction\":0,\"count\":0,\"errors\":{\"other\":0,\"hook\":3,\"conflict\":0}},\"id\":\"2\","
 		+ "\"jsonrpc\":\"2.0\"}";
 
-	private final OkHttpClient client = mock(OkHttpClient.class);
+	private final HttpClient client = mock(HttpClient.class);
 
 	@Test
-	public void testConfiguration() throws IOException {
+	public void testConfiguration() throws Exception {
 		prepareClient(CONFIGURATION)
 			.map(RadixApi::withTrace)
 			.onFailure(failure -> fail(failure.toString()))
@@ -60,7 +53,7 @@ public class SyncRadixApiMempoolTest {
 	}
 
 	@Test
-	public void testData() throws IOException {
+	public void testData() throws Exception {
 		prepareClient(DATA)
 			.map(RadixApi::withTrace)
 			.onFailure(failure -> fail(failure.toString()))
@@ -71,16 +64,13 @@ public class SyncRadixApiMempoolTest {
 					.onSuccess(data -> assertEquals(3L, data.getErrors().getHook())));
 	}
 
-	private Result<RadixApi> prepareClient(String responseBody) throws IOException {
-		var call = mock(Call.class);
-		var response = mock(Response.class);
-		var body = mock(ResponseBody.class);
+	private Result<RadixApi> prepareClient(String responseBody) throws Exception {
+		@SuppressWarnings("unchecked")
+		var response = (HttpResponse<String>) mock(HttpResponse.class);
 
-		when(client.newCall(any())).thenReturn(call);
-		when(call.execute()).thenReturn(response);
-		when(response.body()).thenReturn(body);
-		when(body.string()).thenReturn(NETWORK_ID, responseBody);
+		when(response.body()).thenReturn(NETWORK_ID, responseBody);
+		when(client.<String>send(any(), any())).thenReturn(response);
 
-		return SyncRadixApi.connect(BASE_URL, DEFAULT_PRIMARY_PORT, DEFAULT_SECONDARY_PORT, client);
+		return SyncRadixApi.connect(BASE_URL, RadixApi.DEFAULT_PRIMARY_PORT, RadixApi.DEFAULT_SECONDARY_PORT, client);
 	}
 }

--- a/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiSyncTest.java
+++ b/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiSyncTest.java
@@ -20,21 +20,14 @@ import org.junit.Test;
 
 import com.radixdlt.utils.functional.Result;
 
-import java.io.IOException;
-
-import okhttp3.Call;
-import okhttp3.OkHttpClient;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import static com.radixdlt.client.lib.api.sync.RadixApi.DEFAULT_PRIMARY_PORT;
-import static com.radixdlt.client.lib.api.sync.RadixApi.DEFAULT_SECONDARY_PORT;
 
 public class SyncRadixApiSyncTest {
 	private static final String BASE_URL = "http://localhost/";
@@ -47,10 +40,10 @@ public class SyncRadixApiSyncTest {
 		+ "Diff\":0,\"remoteRequestsProcessed\":38614,\"lastReadMillis\":0,\"targetStateVersion\":814181},\"id\":\"2\""
 		+ ",\"jsonrpc\":\"2.0\"}\n";
 
-	private final OkHttpClient client = mock(OkHttpClient.class);
+	private final HttpClient client = mock(HttpClient.class);
 
 	@Test
-	public void testConfiguration() throws IOException {
+	public void testConfiguration() throws Exception {
 		prepareClient(CONFIGURATION)
 			.map(RadixApi::withTrace)
 			.onFailure(failure -> fail(failure.toString()))
@@ -61,7 +54,7 @@ public class SyncRadixApiSyncTest {
 	}
 
 	@Test
-	public void testData() throws IOException {
+	public void testData() throws Exception {
 		prepareClient(DATA)
 			.map(RadixApi::withTrace)
 			.onFailure(failure -> fail(failure.toString()))
@@ -71,16 +64,13 @@ public class SyncRadixApiSyncTest {
 				.onSuccess(data -> assertEquals(814181L, data.getTargetStateVersion())));
 	}
 
-	private Result<RadixApi> prepareClient(String responseBody) throws IOException {
-		var call = mock(Call.class);
-		var response = mock(Response.class);
-		var body = mock(ResponseBody.class);
+	private Result<RadixApi> prepareClient(String responseBody) throws Exception {
+		@SuppressWarnings("unchecked")
+		var response = (HttpResponse<String>) mock(HttpResponse.class);
 
-		when(client.newCall(any())).thenReturn(call);
-		when(call.execute()).thenReturn(response);
-		when(response.body()).thenReturn(body);
-		when(body.string()).thenReturn(NETWORK_ID, responseBody);
+		when(response.body()).thenReturn(NETWORK_ID, responseBody);
+		when(client.<String>send(any(), any())).thenReturn(response);
 
-		return SyncRadixApi.connect(BASE_URL, DEFAULT_PRIMARY_PORT, DEFAULT_SECONDARY_PORT, client);
+		return SyncRadixApi.connect(BASE_URL, RadixApi.DEFAULT_PRIMARY_PORT, RadixApi.DEFAULT_SECONDARY_PORT, client);
 	}
 }

--- a/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiTokenTest.java
+++ b/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiTokenTest.java
@@ -24,21 +24,14 @@ import com.radixdlt.crypto.exception.PublicKeyException;
 import com.radixdlt.utils.Ints;
 import com.radixdlt.utils.functional.Result;
 
-import java.io.IOException;
-
-import okhttp3.Call;
-import okhttp3.OkHttpClient;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import static com.radixdlt.client.lib.api.sync.RadixApi.DEFAULT_PRIMARY_PORT;
-import static com.radixdlt.client.lib.api.sync.RadixApi.DEFAULT_SECONDARY_PORT;
 
 public class SyncRadixApiTokenTest {
 	private static final String BASE_URL = "http://localhost/";
@@ -49,10 +42,10 @@ public class SyncRadixApiTokenTest {
 		+ "Rads\",\"rri\":\"xrd_dr1qyrs8qwl\",\"description\":\"Radix Tokens\",\"currentSupply\":\"8000000000000"
 		+ "000000000000000\",\"iconURL\":\"https://tokens.radixdlt.com/\"},\"id\":\"2\",\"jsonrpc\":\"2.0\"}\n";
 
-	private final OkHttpClient client = mock(OkHttpClient.class);
+	private final HttpClient client = mock(HttpClient.class);
 
 	@Test
-	public void testNativeToken() throws IOException {
+	public void testNativeToken() throws Exception {
 		prepareClient(NATIVE_TOKEN)
 			.map(RadixApi::withTrace)
 			.onFailure(failure -> fail(failure.toString()))
@@ -62,26 +55,13 @@ public class SyncRadixApiTokenTest {
 	}
 
 	@Test
-	public void testTokenInfo() throws IOException {
+	public void testTokenInfo() throws Exception {
 		prepareClient(NATIVE_TOKEN)
 			.map(RadixApi::withTrace)
 			.onFailure(failure -> fail(failure.toString()))
 			.onSuccess(client -> client.token().describe("xrd_dr1qyrs8qwl")
 				.onFailure(failure -> fail(failure.toString()))
 				.onSuccess(tokenInfoDTO -> assertEquals("Rads", tokenInfoDTO.getName())));
-	}
-
-	private Result<RadixApi> prepareClient(String responseBody) throws IOException {
-		var call = mock(Call.class);
-		var response = mock(Response.class);
-		var body = mock(ResponseBody.class);
-
-		when(client.newCall(any())).thenReturn(call);
-		when(call.execute()).thenReturn(response);
-		when(response.body()).thenReturn(body);
-		when(body.string()).thenReturn(NETWORK_ID, responseBody);
-
-		return SyncRadixApi.connect(BASE_URL, DEFAULT_PRIMARY_PORT, DEFAULT_SECONDARY_PORT, client);
 	}
 
 	private static ECKeyPair keyPairOf(int pk) {
@@ -94,5 +74,15 @@ public class SyncRadixApiTokenTest {
 		} catch (PrivateKeyException | PublicKeyException e) {
 			throw new IllegalArgumentException("Error while generating public key", e);
 		}
+	}
+
+	private Result<RadixApi> prepareClient(String responseBody) throws Exception {
+		@SuppressWarnings("unchecked")
+		var response = (HttpResponse<String>) mock(HttpResponse.class);
+
+		when(response.body()).thenReturn(NETWORK_ID, responseBody);
+		when(client.<String>send(any(), any())).thenReturn(response);
+
+		return SyncRadixApi.connect(BASE_URL, RadixApi.DEFAULT_PRIMARY_PORT, RadixApi.DEFAULT_SECONDARY_PORT, client);
 	}
 }

--- a/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiValidatorTest.java
+++ b/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiValidatorTest.java
@@ -23,13 +23,9 @@ import com.radixdlt.networks.Addressing;
 import com.radixdlt.utils.UInt256;
 import com.radixdlt.utils.functional.Result;
 
-import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
 import java.util.Optional;
-
-import okhttp3.Call;
-import okhttp3.OkHttpClient;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -38,31 +34,28 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import static com.radixdlt.client.lib.api.sync.RadixApi.DEFAULT_PRIMARY_PORT;
-import static com.radixdlt.client.lib.api.sync.RadixApi.DEFAULT_SECONDARY_PORT;
-
 public class SyncRadixApiValidatorTest {
 	private static final String BASE_URL = "http://localhost/";
 
 	private static final String NETWORK_ID = "{\"result\":{\"networkId\":99},\"id\":\"1\",\"jsonrpc\":\"2.0\"}";
 	private static final String LIST = "{\"result\":{\"cursor\":\"dv1q0llj774w40wafpqg5apgd2jxhfc9aj897zk3gvt9uzh59rq9964vjryzf9\""
-		+ ",\"validators\":[{\"totalDelegatedStake\":\"100000000000000000000\",\"rakePercentage\":0,\"address\":\"dv1qfwtmurydewmf"
+		+ ",\"validators\":[{\"totalDelegatedStake\":\"100000000000000000000\",\"validatorFee\":0,\"address\":\"dv1qfwtmurydewmf"
 		+ "64rnrektuh20g8r6svm0cpnpcuuay4ammw2cnumc3jtmxl\",\"infoURL\":\"\",\"ownerDelegation\":\"100000000000000000000\",\"name\""
 		+ ":\"\",\"registered\":true,\"ownerAddress\":\"ddx1qsp9e00sv3h9md825wv0xe0jafaqu02pndlqxv8rnn5jhh0detz0n0qtp2phh\",\"isExt"
-		+ "ernalStakeAccepted\":true},{\"totalDelegatedStake\":\"100000000000000000000\",\"rakePercentage\":0,\"address\":\"dv1q0ll"
+		+ "ernalStakeAccepted\":true},{\"totalDelegatedStake\":\"100000000000000000000\",\"validatorFee\":0,\"address\":\"dv1q0ll"
 		+ "j774w40wafpqg5apgd2jxhfc9aj897zk3gvt9uzh59rq9964vjryzf9\",\"infoURL\":\"\",\"ownerDelegation\":\"100000000000000000000\""
 		+ ",\"name\":\"\",\"registered\":true,\"ownerAddress\":\"ddx1qspll7tm6464am4yypzn59p42g6a8qhkguhc269p3vhs27s5vq5h24sfvvdfj\""
 		+ ",\"isExternalStakeAccepted\":true}]},\"id\":\"2\",\"jsonrpc\":\"2.0\"}\n";
 
-	private static final String LOOKUP = "{\"result\":{\"totalDelegatedStake\":\"4754240000000000000000000\",\"rakePercentage\":0,\""
+	private static final String LOOKUP = "{\"result\":{\"totalDelegatedStake\":\"4754240000000000000000000\",\"validatorFee\":0,\""
 		+ "address\":\"dv1q0llj774w40wafpqg5apgd2jxhfc9aj897zk3gvt9uzh59rq9964vjryzf9\",\"infoURL\":\"\",\"ownerDelegation\":\"10000"
 		+ "0000000000000000\",\"name\":\"\",\"registered\":true,\"ownerAddress\":\"ddx1qspll7tm6464am4yypzn59p42g6a8qhkguhc269p3vhs2"
 		+ "7s5vq5h24sfvvdfj\",\"isExternalStakeAccepted\":true},\"id\":\"2\",\"jsonrpc\":\"2.0\"}\n";
 
-	private final OkHttpClient client = mock(OkHttpClient.class);
+	private final HttpClient client = mock(HttpClient.class);
 
 	@Test
-	public void testList() throws IOException {
+	public void testList() throws Exception {
 		prepareClient(LIST)
 			.map(RadixApi::withTrace)
 			.onFailure(failure -> fail(failure.toString()))
@@ -73,7 +66,7 @@ public class SyncRadixApiValidatorTest {
 	}
 
 	@Test
-	public void testLookup() throws IOException {
+	public void testLookup() throws Exception {
 		var stake = UInt256.from("4754240000000000000000000");
 		var address = ValidatorAddress.of(Addressing.ofNetworkId(99).forValidators()
 			.parse("dv1q0llj774w40wafpqg5apgd2jxhfc9aj897zk3gvt9uzh59rq9964vjryzf9"));
@@ -88,16 +81,13 @@ public class SyncRadixApiValidatorTest {
 					.onSuccess(validatorDTO -> assertEquals(stake, validatorDTO.getTotalDelegatedStake())));
 	}
 
-	private Result<RadixApi> prepareClient(String responseBody) throws IOException {
-		var call = mock(Call.class);
-		var response = mock(Response.class);
-		var body = mock(ResponseBody.class);
+	private Result<RadixApi> prepareClient(String responseBody) throws Exception {
+		@SuppressWarnings("unchecked")
+		var response = (HttpResponse<String>) mock(HttpResponse.class);
 
-		when(client.newCall(any())).thenReturn(call);
-		when(call.execute()).thenReturn(response);
-		when(response.body()).thenReturn(body);
-		when(body.string()).thenReturn(NETWORK_ID, responseBody);
+		when(response.body()).thenReturn(NETWORK_ID, responseBody);
+		when(client.<String>send(any(), any())).thenReturn(response);
 
-		return SyncRadixApi.connect(BASE_URL, DEFAULT_PRIMARY_PORT, DEFAULT_SECONDARY_PORT, client);
+		return SyncRadixApi.connect(BASE_URL, RadixApi.DEFAULT_PRIMARY_PORT, RadixApi.DEFAULT_SECONDARY_PORT, client);
 	}
 }

--- a/radixdlt-regression/src/test/java/com/radix/test/account/Account.java
+++ b/radixdlt-regression/src/test/java/com/radix/test/account/Account.java
@@ -1,17 +1,19 @@
 package com.radix.test.account;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.radix.test.Utils;
 import com.radixdlt.client.lib.api.AccountAddress;
 import com.radixdlt.client.lib.api.sync.RadixApi;
 import com.radixdlt.client.lib.dto.Balance;
-import com.radixdlt.client.lib.dto.TokenInfo;
 import com.radixdlt.client.lib.dto.TokenBalances;
+import com.radixdlt.client.lib.dto.TokenInfo;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.utils.UInt256;
 import com.radixdlt.utils.functional.Result;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
+import java.time.Duration;
 import java.util.stream.Collectors;
 
 /**
@@ -33,8 +35,14 @@ public final class Account implements RadixApi {
     }
 
     @Override
-    public RadixApi withTrace() {
+    public Account withTrace() {
         client.withTrace();
+        return this;
+    }
+
+    @Override
+    public RadixApi withTimeout(Duration timeout) {
+        client.withTimeout(timeout);
         return this;
     }
 


### PR DESCRIPTION
Changes summary:
- Flatten finalize_transaction parameters (remove unnecessary wrapper around `blob`)
- Rename `rakePercentage` to `validatorFee`
- Get rid of OkHttpClient in Java client (replaced with built-in Java client)