### PR TITLE
Rename action; Fix actions in client; Fix fee parameter type

### DIFF
--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/staking/StakingUnstakingValidatorsTest.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/staking/StakingUnstakingValidatorsTest.java
@@ -68,7 +68,7 @@ import com.radixdlt.atom.actions.TransferToken;
 import com.radixdlt.atom.actions.UnregisterValidator;
 import com.radixdlt.atom.actions.UnstakeTokens;
 import com.radixdlt.atom.actions.UpdateAllowDelegationFlag;
-import com.radixdlt.atom.actions.UpdateRake;
+import com.radixdlt.atom.actions.UpdateValidatorFee;
 import com.radixdlt.atom.actions.UpdateValidatorOwnerAddress;
 import com.radixdlt.consensus.bft.BFTNode;
 import com.radixdlt.consensus.bft.Self;
@@ -533,7 +533,7 @@ public class StakingUnstakingValidatorsTest {
 					restartNode(nodeIndex);
 					continue;
 				case 6:
-					action = new UpdateRake(privKey.getPublicKey(), random.nextInt(ValidatorUpdateRakeConstraintScrypt.RAKE_MAX + 1));
+					action = new UpdateValidatorFee(privKey.getPublicKey(), random.nextInt(ValidatorUpdateRakeConstraintScrypt.RAKE_MAX + 1));
 					break;
 				case 7:
 					action = new UpdateValidatorOwnerAddress(privKey.getPublicKey(), REAddr.ofPubKeyAccount(to));

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/ActionType.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/ActionType.java
@@ -37,7 +37,7 @@ public enum ActionType {
 	REGISTER_VALIDATOR("RegisterValidator"),
 	UNREGISTER_VALIDATOR("UnregisterValidator"),
 	UPDATE_VALIDATOR("UpdateValidator"),
-	UPDATE_RAKE("UpdateRake"),
+	UPDATE_VALIDATOR_FEE("UpdateValidatorFee"),
 	UPDATE_OWNER("UpdateValidatorOwnerAddress"),
 	UPDATE_DELEGATION("UpdateAllowDelegationFlag"),
 	CREATE_FIXED("CreateFixedSupplyToken"),

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/ValidatorInfoDetails.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/ValidatorInfoDetails.java
@@ -26,6 +26,7 @@ import com.radixdlt.statecomputer.ValidatorDetails;
 import com.radixdlt.utils.UInt256;
 
 import static com.radixdlt.api.JsonRpcUtil.jsonObject;
+import static com.radixdlt.application.validators.scrypt.ValidatorUpdateRakeConstraintScrypt.RAKE_PERCENTAGE_GRANULARITY;
 
 import static java.util.Objects.requireNonNull;
 
@@ -150,7 +151,7 @@ public class ValidatorInfoDetails {
 			.put("infoURL", infoUrl)
 			.put("totalDelegatedStake", totalStake)
 			.put("ownerDelegation", ownerStake)
-			.put("validatorFee", percentage)
+			.put("validatorFee", (double) percentage / (double) RAKE_PERCENTAGE_GRANULARITY + "")
 			.put("registered", registered)
 			.put("isExternalStakeAccepted", externalStakesAllowed);
 	}

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/action/TransactionAction.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/action/TransactionAction.java
@@ -60,7 +60,7 @@ public interface TransactionAction {
 		return new UpdateValidatorAction(validatorKey, name.orElse(null), url.orElse(null));
 	}
 
-	static TransactionAction updateRake(ECPublicKey validatorKey, int percentage) {
+	static TransactionAction updateValidatorFee(ECPublicKey validatorKey, int percentage) {
 		return new UpdateRakeAction(validatorKey, percentage);
 	}
 

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/AccountInfoService.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/AccountInfoService.java
@@ -37,6 +37,7 @@ import com.radixdlt.utils.UInt384;
 
 import static com.radixdlt.api.JsonRpcUtil.jsonArray;
 import static com.radixdlt.api.JsonRpcUtil.jsonObject;
+import static com.radixdlt.application.validators.scrypt.ValidatorUpdateRakeConstraintScrypt.RAKE_PERCENTAGE_GRANULARITY;
 
 public class AccountInfoService {
 	private final RadixEngine<LedgerAndBFTProof> radixEngine;
@@ -81,14 +82,14 @@ public class AccountInfoService {
 				.put("url", details.getInfoUrl())
 				.put("registered", details.isRegistered())
 				.put("owner", addressing.forAccounts().of(details.getOwner()))
-				.put("validatorFee", details.getPercentage())
+				.put("validatorFee", (double) details.getPercentage() / (double) RAKE_PERCENTAGE_GRANULARITY + "")
 				.put("allowDelegation", details.isExternalStakesAllowed()),
 			() -> result
 				.put("name", "")
 				.put("url", "")
 				.put("registered", false)
 				.put("owner", addressing.forAccounts().of(REAddr.ofPubKeyAccount(bftKey)))
-				.put("validatorFee", 0)
+				.put("validatorFee", 0.0 + "")
 				.put("allowDelegation", true)
 		);
 

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/ActionParserService.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/ActionParserService.java
@@ -27,6 +27,7 @@ import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.identifiers.REAddr;
 import com.radixdlt.networks.Addressing;
 import com.radixdlt.utils.UInt256;
+import com.radixdlt.utils.functional.Failure;
 import com.radixdlt.utils.functional.Result;
 
 import java.util.ArrayList;
@@ -37,7 +38,11 @@ import java.util.stream.Stream;
 import static com.radixdlt.api.data.ApiErrors.INVALID_ACTION_DATA;
 import static com.radixdlt.api.data.ApiErrors.MISSING_FIELD;
 import static com.radixdlt.api.data.ApiErrors.UNSUPPORTED_ACTION;
+import static com.radixdlt.application.validators.scrypt.ValidatorUpdateRakeConstraintScrypt.RAKE_MAX;
+import static com.radixdlt.application.validators.scrypt.ValidatorUpdateRakeConstraintScrypt.RAKE_MIN;
+import static com.radixdlt.application.validators.scrypt.ValidatorUpdateRakeConstraintScrypt.RAKE_PERCENTAGE_GRANULARITY;
 import static com.radixdlt.identifiers.CommonErrors.UNABLE_TO_DECODE;
+import static com.radixdlt.identifiers.CommonErrors.VALUE_OUT_OF_RANGE;
 import static com.radixdlt.utils.functional.Result.allOf;
 import static com.radixdlt.utils.functional.Result.wrap;
 
@@ -133,11 +138,11 @@ public final class ActionParserService {
 					optionalUrl(element)
 				).map(TransactionAction::update);
 
-			case UPDATE_RAKE:
+			case UPDATE_VALIDATOR_FEE:
 				return allOf(
 					validator(element),
-					percentage(element)
-				).map(TransactionAction::updateRake);
+					fee(element)
+				).map(TransactionAction::updateValidatorFee);
 
 			case UPDATE_DELEGATION:
 				return allOf(
@@ -186,9 +191,16 @@ public final class ActionParserService {
 			.flatMap(p -> addressing.forResources().parseFunctional(p).map(t -> t.map((__, addr) -> addr)));
 	}
 
-	private Result<Integer> percentage(JSONObject element) {
+	private static final Failure FEE_BOUNDS_FAILURE = VALUE_OUT_OF_RANGE.with(
+		(double) RAKE_MIN / (double) RAKE_PERCENTAGE_GRANULARITY + "",
+		(double) RAKE_MAX / (double) RAKE_PERCENTAGE_GRANULARITY + ""
+	);
+
+	private Result<Integer> fee(JSONObject element) {
 		return param(element, "validatorFee")
-			.flatMap(parameter -> wrap(UNABLE_TO_DECODE, () -> Integer.parseInt(parameter)));
+			.flatMap(parameter -> wrap(UNABLE_TO_DECODE, () -> Double.parseDouble(parameter)))
+			.map(doublePercentage -> (int) (doublePercentage * RAKE_PERCENTAGE_GRANULARITY))
+			.filter(percentage -> percentage >= RAKE_MIN && percentage <= RAKE_MAX, FEE_BOUNDS_FAILURE);
 	}
 
 	private Result<Boolean> allowDelegation(JSONObject element) {

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/RERulesVersion.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/RERulesVersion.java
@@ -39,7 +39,7 @@ import com.radixdlt.atom.actions.UnregisterValidator;
 import com.radixdlt.atom.actions.UnstakeOwnership;
 import com.radixdlt.atom.actions.UnstakeTokens;
 import com.radixdlt.atom.actions.UpdateAllowDelegationFlag;
-import com.radixdlt.atom.actions.UpdateRake;
+import com.radixdlt.atom.actions.UpdateValidatorFee;
 import com.radixdlt.atom.actions.UpdateValidatorMetadata;
 import com.radixdlt.atom.actions.UpdateValidatorOwnerAddress;
 import com.radixdlt.application.system.construction.CreateSystemConstructorV2;
@@ -142,7 +142,7 @@ public enum RERulesVersion {
 				.put(UpdateValidatorMetadata.class, new UpdateValidatorConstructor())
 				.put(FeeReservePut.class, new FeeReservePutConstructor())
 				.put(FeeReserveComplete.class, new FeeReserveCompleteConstructor(config.getFeeTable()))
-				.put(UpdateRake.class, new UpdateRakeConstructor(
+				.put(UpdateValidatorFee.class, new UpdateRakeConstructor(
 					rakeIncreaseDebouncerEpochLength,
 					ValidatorUpdateRakeConstraintScrypt.MAX_RAKE_INCREASE
 				))

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/api/service/ActionParserServiceTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/api/service/ActionParserServiceTest.java
@@ -17,8 +17,10 @@
 
 package com.radixdlt.api.service;
 
+import com.radixdlt.atom.actions.UpdateValidatorFee;
 import com.radixdlt.networks.Addressing;
 import com.radixdlt.networks.Network;
+
 import org.json.JSONArray;
 import org.junit.Assert;
 import org.junit.Test;
@@ -338,6 +340,56 @@ public class ActionParserServiceTest {
 	}
 
 	@Test
+	public void updateValidatorFeeIsParsedCorrectly() {
+		var key = ECKeyPair.generateNew().getPublicKey();
+		var validatorAddr = addressing.forValidators().of(key);
+
+		var source = "[{\"type\":\"UpdateValidatorFee\", \"validator\":\"%s\", \"validatorFee\":\"1.2345\"}]";
+		var actions = jsonArray(String.format(source, validatorAddr));
+
+		actionParserService.parse(actions)
+			.onFailure(this::fail)
+			.onSuccess(parsed -> {
+				assertEquals(1, parsed.size());
+
+				parsed.get(0).toAction().findAny()
+					.filter(UpdateValidatorFee.class::isInstance)
+					.map(UpdateValidatorFee.class::cast)
+					.ifPresentOrElse(
+						updateValidatorFee -> {
+							assertEquals(key, updateValidatorFee.validatorKey());
+							assertEquals(123, updateValidatorFee.getFeePercentage());
+						},
+						Assert::fail
+					);
+			});
+	}
+
+	@Test
+	public void updateValidatorFeeIsCheckedForUpperBound() {
+		var key = ECKeyPair.generateNew().getPublicKey();
+		var validatorAddr = addressing.forValidators().of(key);
+
+		var source = "[{\"type\":\"UpdateValidatorFee\", \"validator\":\"%s\", \"validatorFee\":\"100.1\"}]";
+		var actions = jsonArray(String.format(source, validatorAddr));
+
+		actionParserService.parse(actions)
+			.onSuccessDo(this::failureExpected);
+	}
+
+	@Test
+	public void updateValidatorFeeIsCheckedForLowerBound() {
+		var key = ECKeyPair.generateNew().getPublicKey();
+		var validatorAddr = addressing.forValidators().of(key);
+
+		var source = "[{\"type\":\"UpdateValidatorFee\", \"validator\":\"%s\", \"validatorFee\":\"-0.01\"}]";
+		var actions = jsonArray(String.format(source, validatorAddr));
+
+		actionParserService.parse(actions)
+			.onSuccessDo(this::failureExpected);
+	}
+
+	@Test
 	public void unregisterValidatorIsParsedCorrectlyWithUrlAndName() {
 		var key = ECKeyPair.generateNew().getPublicKey();
 		var validatorAddr = addressing.forValidators().of(key);
@@ -532,5 +584,9 @@ public class ActionParserServiceTest {
 
 	private void fail(Failure failure) {
 		Assert.fail(failure.message());
+	}
+
+	private void failureExpected() {
+		Assert.fail("Expected failure result, got success instead");
 	}
 }

--- a/radixdlt-engine/src/main/java/com/radixdlt/application/validators/construction/UpdateAllowDelegationFlagConstructor.java
+++ b/radixdlt-engine/src/main/java/com/radixdlt/application/validators/construction/UpdateAllowDelegationFlagConstructor.java
@@ -32,12 +32,12 @@ public class UpdateAllowDelegationFlagConstructor implements ActionConstructor<U
 	public void construct(UpdateAllowDelegationFlag action, TxBuilder builder) throws TxBuilderException {
 		builder.swap(
 			AllowDelegationFlag.class,
-			p -> p.getValidatorKey().equals(action.getValidatorKey()) && p.allowsDelegation() != action.allowDelegation(),
-			Optional.of(action.getValidatorKey()),
+			p -> p.getValidatorKey().equals(action.validatorKey()) && p.allowsDelegation() != action.allowDelegation(),
+			Optional.of(action.validatorKey()),
 			() -> new TxBuilderException("Flag already set to " + action.allowDelegation())
 		).with(
 			substateDown -> List.of(new AllowDelegationFlag(
-				action.getValidatorKey(),
+				action.validatorKey(),
 				action.allowDelegation()
 			))
 		);

--- a/radixdlt-engine/src/main/java/com/radixdlt/application/validators/construction/UpdateValidatorOwnerConstructor.java
+++ b/radixdlt-engine/src/main/java/com/radixdlt/application/validators/construction/UpdateValidatorOwnerConstructor.java
@@ -33,14 +33,14 @@ public class UpdateValidatorOwnerConstructor implements ActionConstructor<Update
 	public void construct(UpdateValidatorOwnerAddress action, TxBuilder txBuilder) throws TxBuilderException {
 		txBuilder.down(
 			ValidatorOwnerCopy.class,
-			p -> p.getValidatorKey().equals(action.getValidatorKey()),
-			Optional.of(action.getValidatorKey()),
+			p -> p.getValidatorKey().equals(action.validatorKey()),
+			Optional.of(action.validatorKey()),
 			() -> new TxBuilderException("Cannot find state")
 		);
 
 		var curEpoch = txBuilder.read(EpochData.class, p -> true, Optional.empty(), "Cannot find epoch");
 		txBuilder.up(new ValidatorOwnerCopy(
-			OptionalLong.of(curEpoch.getEpoch() + 1), action.getValidatorKey(), action.getOwnerAddress()
+			OptionalLong.of(curEpoch.getEpoch() + 1), action.validatorKey(), action.getOwnerAddress()
 		));
 		txBuilder.end();
 	}

--- a/radixdlt-engine/src/main/java/com/radixdlt/atom/TxValidatorAction.java
+++ b/radixdlt-engine/src/main/java/com/radixdlt/atom/TxValidatorAction.java
@@ -16,26 +16,13 @@
  *
  */
 
-package com.radixdlt.atom.actions;
+package com.radixdlt.atom;
 
-import com.radixdlt.atom.TxValidatorAction;
 import com.radixdlt.crypto.ECPublicKey;
 
-public final class UpdateAllowDelegationFlag implements TxValidatorAction {
-	private final ECPublicKey validatorKey;
-	private final boolean allowDelegation;
-
-	public UpdateAllowDelegationFlag(ECPublicKey validatorKey, boolean allowDelegation) {
-		this.validatorKey = validatorKey;
-		this.allowDelegation = allowDelegation;
-	}
-
-	@Override
-	public ECPublicKey validatorKey() {
-		return validatorKey;
-	}
-
-	public boolean allowDelegation() {
-		return allowDelegation;
-	}
+/**
+ * Marker interface for actions containing validator key.
+ */
+public interface TxValidatorAction extends TxAction {
+	ECPublicKey validatorKey();
 }

--- a/radixdlt-engine/src/main/java/com/radixdlt/atom/actions/RegisterValidator.java
+++ b/radixdlt-engine/src/main/java/com/radixdlt/atom/actions/RegisterValidator.java
@@ -18,16 +18,17 @@
 
 package com.radixdlt.atom.actions;
 
-import com.radixdlt.atom.TxAction;
+import com.radixdlt.atom.TxValidatorAction;
 import com.radixdlt.crypto.ECPublicKey;
 
-public final class RegisterValidator implements TxAction {
+public final class RegisterValidator implements TxValidatorAction {
 	private final ECPublicKey validatorKey;
 
 	public RegisterValidator(ECPublicKey validatorKey) {
 		this.validatorKey = validatorKey;
 	}
 
+	@Override
 	public ECPublicKey validatorKey() {
 		return validatorKey;
 	}

--- a/radixdlt-engine/src/main/java/com/radixdlt/atom/actions/UnregisterValidator.java
+++ b/radixdlt-engine/src/main/java/com/radixdlt/atom/actions/UnregisterValidator.java
@@ -18,18 +18,19 @@
 
 package com.radixdlt.atom.actions;
 
-import com.radixdlt.atom.TxAction;
+import com.radixdlt.atom.TxValidatorAction;
 import com.radixdlt.crypto.ECPublicKey;
 
 import java.util.Objects;
 
-public final class UnregisterValidator implements TxAction {
+public final class UnregisterValidator implements TxValidatorAction {
 	private final ECPublicKey validatorKey;
 
 	public UnregisterValidator(ECPublicKey validatorKey) {
 		this.validatorKey = Objects.requireNonNull(validatorKey);
 	}
 
+	@Override
 	public ECPublicKey validatorKey() {
 		return validatorKey;
 	}

--- a/radixdlt-engine/src/main/java/com/radixdlt/atom/actions/UpdateValidatorFee.java
+++ b/radixdlt-engine/src/main/java/com/radixdlt/atom/actions/UpdateValidatorFee.java
@@ -18,23 +18,27 @@
 
 package com.radixdlt.atom.actions;
 
-import com.radixdlt.atom.TxAction;
+import com.radixdlt.atom.TxValidatorAction;
 import com.radixdlt.crypto.ECPublicKey;
 
-public class UpdateRake implements TxAction {
+/**
+ * @see com.radixdlt.application.validators.scrypt.ValidatorUpdateRakeConstraintScrypt for details
+ */
+public class UpdateValidatorFee implements TxValidatorAction {
 	private final ECPublicKey validatorKey;
-	private final int rakePercentage;
+	private final int feePercentage;
 
-	public UpdateRake(ECPublicKey validatorKey, int rakePercentage) {
+	public UpdateValidatorFee(ECPublicKey validatorKey, int feePercentage) {
 		this.validatorKey = validatorKey;
-		this.rakePercentage = rakePercentage;
+		this.feePercentage = feePercentage;
 	}
 
-	public ECPublicKey getValidatorKey() {
+	@Override
+	public ECPublicKey validatorKey() {
 		return validatorKey;
 	}
 
-	public int getRakePercentage() {
-		return rakePercentage;
+	public int getFeePercentage() {
+		return feePercentage;
 	}
 }

--- a/radixdlt-engine/src/main/java/com/radixdlt/atom/actions/UpdateValidatorMetadata.java
+++ b/radixdlt-engine/src/main/java/com/radixdlt/atom/actions/UpdateValidatorMetadata.java
@@ -18,12 +18,12 @@
 
 package com.radixdlt.atom.actions;
 
-import com.radixdlt.atom.TxAction;
+import com.radixdlt.atom.TxValidatorAction;
 import com.radixdlt.crypto.ECPublicKey;
 
 import java.util.Objects;
 
-public class UpdateValidatorMetadata implements TxAction {
+public class UpdateValidatorMetadata implements TxValidatorAction {
 	private final ECPublicKey validatorKey;
 	private final String name;
 	private final String url;
@@ -38,6 +38,7 @@ public class UpdateValidatorMetadata implements TxAction {
 		this.url = url;
 	}
 
+	@Override
 	public ECPublicKey validatorKey() {
 		return validatorKey;
 	}

--- a/radixdlt-engine/src/main/java/com/radixdlt/atom/actions/UpdateValidatorOwnerAddress.java
+++ b/radixdlt-engine/src/main/java/com/radixdlt/atom/actions/UpdateValidatorOwnerAddress.java
@@ -18,11 +18,11 @@
 
 package com.radixdlt.atom.actions;
 
-import com.radixdlt.atom.TxAction;
+import com.radixdlt.atom.TxValidatorAction;
 import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.identifiers.REAddr;
 
-public final class UpdateValidatorOwnerAddress implements TxAction {
+public final class UpdateValidatorOwnerAddress implements TxValidatorAction {
 	private final ECPublicKey validatorKey;
 	private final REAddr ownerAddress;
 
@@ -31,7 +31,8 @@ public final class UpdateValidatorOwnerAddress implements TxAction {
 		this.ownerAddress = ownerAddress;
 	}
 
-	public ECPublicKey getValidatorKey() {
+	@Override
+	public ECPublicKey validatorKey() {
 		return validatorKey;
 	}
 

--- a/radixdlt-engine/src/test/java/com/radixdlt/application/validators/UpdateValidatorFeeTest.java
+++ b/radixdlt-engine/src/test/java/com/radixdlt/application/validators/UpdateValidatorFeeTest.java
@@ -27,7 +27,7 @@ import com.radixdlt.application.validators.scrypt.ValidatorConstraintScryptV2;
 import com.radixdlt.application.validators.scrypt.ValidatorUpdateRakeConstraintScrypt;
 import com.radixdlt.atom.REConstructor;
 import com.radixdlt.atom.actions.CreateSystem;
-import com.radixdlt.atom.actions.UpdateRake;
+import com.radixdlt.atom.actions.UpdateValidatorFee;
 import com.radixdlt.atomos.CMAtomOS;
 import com.radixdlt.constraintmachine.ConstraintMachine;
 import com.radixdlt.constraintmachine.PermissionLevel;
@@ -44,7 +44,7 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Set;
 
-public class UpdateRakeTest {
+public class UpdateValidatorFeeTest {
 	private RadixEngine<Void> engine;
 	private EngineStore<Void> store;
 	private SubstateSerialization serialization;
@@ -66,7 +66,7 @@ public class UpdateRakeTest {
 			serialization,
 			REConstructor.newBuilder()
 				.put(CreateSystem.class, new CreateSystemConstructorV2())
-				.put(UpdateRake.class, new UpdateRakeConstructor(2, ValidatorUpdateRakeConstraintScrypt.MAX_RAKE_INCREASE))
+				.put(UpdateValidatorFee.class, new UpdateRakeConstructor(2, ValidatorUpdateRakeConstraintScrypt.MAX_RAKE_INCREASE))
 				.build(),
 			cm,
 			store
@@ -81,7 +81,7 @@ public class UpdateRakeTest {
 		var key = ECKeyPair.generateNew();
 
 		// Act and Assert
-		var registerTxn = this.engine.construct(new UpdateRake(key.getPublicKey(), 100))
+		var registerTxn = this.engine.construct(new UpdateValidatorFee(key.getPublicKey(), 100))
 			.signAndBuild(key::sign);
 		this.engine.execute(List.of(registerTxn));
 	}

--- a/radixdlt-java-common/src/main/java/com/radixdlt/identifiers/CommonErrors.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/identifiers/CommonErrors.java
@@ -31,6 +31,7 @@ public enum CommonErrors implements Failure {
 	SSL_KEY_ERROR(1605, "SSL Key error: {0}"),
 	SSL_ALGORITHM_ERROR(1606, "SSL algorithm error: {0}"),
 	SSL_GENERAL_ERROR(1607, "SSL algorithm error: {0}"),
+	VALUE_OUT_OF_RANGE(1608, "Parameter must be between {0} and {1}"),
 	CANT_MAKE_RECOVERABLE(1701, "Unable to convert signature to recoverable {0}"),
 	INVALID_RADIX_ADDRESS(1702, "Invalid RadixAddress {0}"),
 	INVALID_UINT_VALUE(1703, "Invalid UInt256/UInt384 value {0}"),

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/ActionType.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/ActionType.java
@@ -37,7 +37,7 @@ public enum ActionType {
 	UPDATE_VALIDATOR("UpdateValidator"),
 	UPDATE_VALIDATOR_FEE("UpdateValidatorFee"),
 	UPDATE_VALIDATOR_OWNER("UpdateValidatorOwnerAddress"),
-	UPDATE_VALIDATOR_DELEGATION_FLAG("UpdateAllowDelegationFlag"),//
+	UPDATE_VALIDATOR_DELEGATION_FLAG("UpdateAllowDelegationFlag"),
 	CREATE_FIXED("CreateFixedSupplyToken"),
 	CREATE_MUTABLE("CreateMutableSupplyToken"),
 	UNKNOWN("Other");

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/ActionType.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/ActionType.java
@@ -19,15 +19,11 @@ package com.radixdlt.client.lib.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.radixdlt.utils.functional.Result;
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static com.radixdlt.client.lib.api.ClientLibraryErrors.UNKNOWN_ACTION;
 
 public enum ActionType {
 	MSG("Message"),
@@ -39,6 +35,9 @@ public enum ActionType {
 	REGISTER_VALIDATOR("RegisterValidator"),
 	UNREGISTER_VALIDATOR("UnregisterValidator"),
 	UPDATE_VALIDATOR("UpdateValidator"),
+	UPDATE_VALIDATOR_FEE("UpdateValidatorFee"),
+	UPDATE_VALIDATOR_OWNER("UpdateValidatorOwnerAddress"),
+	UPDATE_VALIDATOR_DELEGATION_FLAG("UpdateAllowDelegationFlag"),//
 	CREATE_FIXED("CreateFixedSupplyToken"),
 	CREATE_MUTABLE("CreateMutableSupplyToken"),
 	UNKNOWN("Other");
@@ -66,11 +65,5 @@ public enum ActionType {
 		}
 
 		return result;
-	}
-
-	public static Result<ActionType> fromString(String action) {
-		return Optional.ofNullable(TO_ACTION_TYPE.get(action))
-			.map(Result::ok)
-			.orElseGet(() -> UNKNOWN_ACTION.with(action).result());
 	}
 }

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/TransactionRequest.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/TransactionRequest.java
@@ -18,7 +18,6 @@
 package com.radixdlt.client.lib.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-//import com.radixdlt.client.lib.dto.Action;
 import com.radixdlt.client.lib.api.action.Action;
 import com.radixdlt.client.lib.api.action.BurnAction;
 import com.radixdlt.client.lib.api.action.CreateFixedTokenAction;
@@ -30,6 +29,9 @@ import com.radixdlt.client.lib.api.action.TransferAction;
 import com.radixdlt.client.lib.api.action.UnregisterValidatorAction;
 import com.radixdlt.client.lib.api.action.UnstakeAction;
 import com.radixdlt.client.lib.api.action.UpdateValidatorAction;
+import com.radixdlt.client.lib.api.action.UpdateValidatorAllowDelegationFlagAction;
+import com.radixdlt.client.lib.api.action.UpdateValidatorFeeAction;
+import com.radixdlt.client.lib.api.action.UpdateValidatorOwnerAction;
 import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.utils.UInt256;
 
@@ -111,18 +113,33 @@ public class TransactionRequest {
 			return this;
 		}
 
-		public TransactionRequestBuilder registerValidator(ValidatorAddress delegate, Optional<String> name, Optional<String> url) {
-			actions.add(new RegisterValidatorAction(delegate, name.orElse(null), url.orElse(null)));
+		public TransactionRequestBuilder registerValidator(ValidatorAddress validator, Optional<String> name, Optional<String> url) {
+			actions.add(new RegisterValidatorAction(validator, name.orElse(null), url.orElse(null)));
 			return this;
 		}
 
-		public TransactionRequestBuilder unregisterValidator(ValidatorAddress delegate, Optional<String> name, Optional<String> url) {
-			actions.add(new UnregisterValidatorAction(delegate, name.orElse(null), url.orElse(null)));
+		public TransactionRequestBuilder unregisterValidator(ValidatorAddress validator, Optional<String> name, Optional<String> url) {
+			actions.add(new UnregisterValidatorAction(validator, name.orElse(null), url.orElse(null)));
 			return this;
 		}
 
-		public TransactionRequestBuilder updateValidator(ValidatorAddress delegate, Optional<String> name, Optional<String> url) {
-			actions.add(new UpdateValidatorAction(delegate, name.orElse(null), url.orElse(null)));
+		public TransactionRequestBuilder updateValidator(ValidatorAddress validator, Optional<String> name, Optional<String> url) {
+			actions.add(new UpdateValidatorAction(validator, name.orElse(null), url.orElse(null)));
+			return this;
+		}
+
+		public TransactionRequestBuilder updateValidatorAllowDelegationFlag(ValidatorAddress validator, boolean allowDelegation) {
+			actions.add(new UpdateValidatorAllowDelegationFlagAction(validator, allowDelegation));
+			return this;
+		}
+
+		public TransactionRequestBuilder updateValidatorFee(ValidatorAddress validator, double validatorFee) {
+			actions.add(new UpdateValidatorFeeAction(validator, validatorFee));
+			return this;
+		}
+
+		public TransactionRequestBuilder updateValidatorOwner(ValidatorAddress validator, AccountAddress owner) {
+			actions.add(new UpdateValidatorOwnerAction(validator, owner));
 			return this;
 		}
 

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/action/StakeAction.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/action/StakeAction.java
@@ -47,8 +47,7 @@ public class StakeAction implements Action {
 
 	public String toJSON(int networkId) {
 		return String.format("{\"from\":\"%s\",\"validator\":\"%s\",\"amount\":\"%s\",\"type\":\"StakeTokens\"}",
-							 from.toString(networkId), validator.toString(networkId), amount
-		);
+							 from.toString(networkId), validator.toString(networkId), amount);
 	}
 
 	@Override

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/action/UpdateValidatorAllowDelegationFlagAction.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/action/UpdateValidatorAllowDelegationFlagAction.java
@@ -6,36 +6,29 @@
  * compliance with the License.  You may obtain a copy of the
  * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied.  See the License for the specific
  * language governing permissions and limitations under the License.
- *
  */
 
-package com.radixdlt.atom.actions;
+package com.radixdlt.client.lib.api.action;
 
-import com.radixdlt.atom.TxValidatorAction;
-import com.radixdlt.crypto.ECPublicKey;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.radixdlt.client.lib.api.ActionType;
+import com.radixdlt.client.lib.api.ValidatorAddress;
 
-public final class UpdateAllowDelegationFlag implements TxValidatorAction {
-	private final ECPublicKey validatorKey;
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class UpdateValidatorAllowDelegationFlagAction implements Action {
+	private final ActionType type = ActionType.UPDATE_VALIDATOR_DELEGATION_FLAG;
+	private final ValidatorAddress validator;
 	private final boolean allowDelegation;
 
-	public UpdateAllowDelegationFlag(ECPublicKey validatorKey, boolean allowDelegation) {
-		this.validatorKey = validatorKey;
+	public UpdateValidatorAllowDelegationFlagAction(ValidatorAddress validator, boolean allowDelegation) {
+		this.validator = validator;
 		this.allowDelegation = allowDelegation;
-	}
-
-	@Override
-	public ECPublicKey validatorKey() {
-		return validatorKey;
-	}
-
-	public boolean allowDelegation() {
-		return allowDelegation;
 	}
 }

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/action/UpdateValidatorFeeAction.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/action/UpdateValidatorFeeAction.java
@@ -15,25 +15,20 @@
  * language governing permissions and limitations under the License.
  */
 
-package com.radixdlt.api.data.action;
+package com.radixdlt.client.lib.api.action;
 
-import com.radixdlt.atom.TxAction;
-import com.radixdlt.atom.actions.UpdateValidatorFee;
-import com.radixdlt.crypto.ECPublicKey;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.radixdlt.client.lib.api.ActionType;
+import com.radixdlt.client.lib.api.ValidatorAddress;
 
-import java.util.stream.Stream;
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class UpdateValidatorFeeAction implements Action {
+	private final ActionType type = ActionType.UPDATE_VALIDATOR_FEE;
+	private final ValidatorAddress validator;
+	private final double validatorFee;
 
-class UpdateRakeAction implements TransactionAction {
-	private final ECPublicKey validatorKey;
-	private final int rakePercentage;
-
-	UpdateRakeAction(ECPublicKey validatorKey, int rakePercentage) {
-		this.validatorKey = validatorKey;
-		this.rakePercentage = rakePercentage;
-	}
-
-	@Override
-	public Stream<TxAction> toAction() {
-		return Stream.of(new UpdateValidatorFee(validatorKey, rakePercentage));
+	public UpdateValidatorFeeAction(ValidatorAddress validator, double validatorFee) {
+		this.validator = validator;
+		this.validatorFee = validatorFee;
 	}
 }

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/action/UpdateValidatorOwnerAction.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/action/UpdateValidatorOwnerAction.java
@@ -1,0 +1,35 @@
+/*
+ * (C) Copyright 2021 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.client.lib.api.action;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.radixdlt.client.lib.api.AccountAddress;
+import com.radixdlt.client.lib.api.ActionType;
+import com.radixdlt.client.lib.api.ValidatorAddress;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class UpdateValidatorOwnerAction implements Action {
+	private final ActionType type = ActionType.UPDATE_VALIDATOR_OWNER;
+	private final ValidatorAddress validator;
+	private final AccountAddress owner;
+
+	public UpdateValidatorOwnerAction(ValidatorAddress validator, AccountAddress owner) {
+		this.validator = validator;
+		this.owner = owner;
+	}
+}

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/dto/LocalValidatorInfo.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/dto/LocalValidatorInfo.java
@@ -34,7 +34,7 @@ public final class LocalValidatorInfo {
 	private final boolean registered;
 	private final List<DelegatedStake> stakes;
 	private final AccountAddress owner;
-	private final int rakePercentage;
+	private final double validatorFee;
 	private final boolean allowDelegation;
 
 	public LocalValidatorInfo(
@@ -45,7 +45,7 @@ public final class LocalValidatorInfo {
 		boolean registered,
 		List<DelegatedStake> stakes,
 		AccountAddress owner,
-		int rakePercentage,
+		double validatorFee,
 		boolean allowDelegation
 	) {
 		this.address = address;
@@ -55,7 +55,7 @@ public final class LocalValidatorInfo {
 		this.registered = registered;
 		this.stakes = stakes;
 		this.owner = owner;
-		this.rakePercentage = rakePercentage;
+		this.validatorFee = validatorFee;
 		this.allowDelegation = allowDelegation;
 	}
 
@@ -68,10 +68,10 @@ public final class LocalValidatorInfo {
 		@JsonProperty(value = "registered", required = true) boolean registered,
 		@JsonProperty(value = "stakes", required = true) List<DelegatedStake> stakes,
 		@JsonProperty(value = "owner", required = true) AccountAddress owner,
-		@JsonProperty(value = "validatorFee", required = true) int rakePercentage,
+		@JsonProperty(value = "validatorFee", required = true) double validatorFee,
 		@JsonProperty(value = "allowDelegation", required = true) boolean allowDelegation
 	) {
-		return new LocalValidatorInfo(address, totalStake, name, url, registered, stakes, owner, rakePercentage, allowDelegation);
+		return new LocalValidatorInfo(address, totalStake, name, url, registered, stakes, owner, validatorFee, allowDelegation);
 	}
 
 	@Override
@@ -86,7 +86,7 @@ public final class LocalValidatorInfo {
 
 		var that = (LocalValidatorInfo) o;
 		return registered == that.registered
-			&& rakePercentage == that.rakePercentage
+			&& Double.compare(that.validatorFee, validatorFee) == 0
 			&& allowDelegation == that.allowDelegation
 			&& address.equals(that.address)
 			&& totalStake.equals(that.totalStake)
@@ -98,17 +98,22 @@ public final class LocalValidatorInfo {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(address, totalStake, name, url, registered, stakes, owner, rakePercentage, allowDelegation);
+		return Objects.hash(address, totalStake, name, url, registered, stakes, owner, validatorFee, allowDelegation);
 	}
 
 	@Override
 	public String toString() {
-		return "{address:" + address
-			+ ", totalStake:" + totalStake
-			+ ", name:'" + name + '\''
-			+ ", url:'" + url + '\''
-			+ ", registered:" + registered
-			+ ", stakes:" + stakes + '}';
+		return "{"
+			+ "address=" + address
+			+ ", totalStake=" + totalStake
+			+ ", name='" + name + '\''
+			+ ", url='" + url + '\''
+			+ ", registered=" + registered
+			+ ", stakes=" + stakes
+			+ ", owner=" + owner
+			+ ", validatorFee=" + validatorFee
+			+ ", allowDelegation=" + allowDelegation
+			+ '}';
 	}
 
 	public ValidatorAddress getAddress() {
@@ -133,5 +138,17 @@ public final class LocalValidatorInfo {
 
 	public List<DelegatedStake> getStakes() {
 		return stakes;
+	}
+
+	public AccountAddress getOwner() {
+		return owner;
+	}
+
+	public double getValidatorFee() {
+		return validatorFee;
+	}
+
+	public boolean isAllowDelegation() {
+		return allowDelegation;
 	}
 }

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/dto/ValidatorDTO.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/dto/ValidatorDTO.java
@@ -32,7 +32,7 @@ public final class ValidatorDTO {
 	private final String infoURL;
 	private final UInt256 totalDelegatedStake;
 	private final UInt256 ownerDelegation;
-	private final long percentage;
+	private final double validatorFee;
 	private final boolean isExternalStakeAccepted;
 	private final boolean registered;
 
@@ -43,7 +43,7 @@ public final class ValidatorDTO {
 		String infoURL,
 		UInt256 totalDelegatedStake,
 		UInt256 ownerDelegation,
-		long percentage,
+		double validatorFee,
 		boolean isExternalStakeAccepted,
 		boolean registered
 	) {
@@ -53,7 +53,7 @@ public final class ValidatorDTO {
 		this.infoURL = infoURL;
 		this.totalDelegatedStake = totalDelegatedStake;
 		this.ownerDelegation = ownerDelegation;
-		this.percentage = percentage;
+		this.validatorFee = validatorFee;
 		this.isExternalStakeAccepted = isExternalStakeAccepted;
 		this.registered = registered;
 	}
@@ -66,7 +66,7 @@ public final class ValidatorDTO {
 		@JsonProperty(value = "infoURL", required = true) String infoURL,
 		@JsonProperty(value = "totalDelegatedStake", required = true) UInt256 totalDelegatedStake,
 		@JsonProperty(value = "ownerDelegation", required = true) UInt256 ownerDelegation,
-		@JsonProperty(value = "validatorFee", required = true) long percentage,
+		@JsonProperty(value = "validatorFee", required = true) double validatorFee,
 		@JsonProperty(value = "isExternalStakeAccepted", required = true) boolean isExternalStakeAccepted,
 		@JsonProperty(value = "registered", required = true) boolean registered
 	) {
@@ -77,7 +77,7 @@ public final class ValidatorDTO {
 
 		return new ValidatorDTO(
 			address, ownerAddress, name, infoURL, totalDelegatedStake,
-			ownerDelegation, percentage, isExternalStakeAccepted, registered
+			ownerDelegation, validatorFee, isExternalStakeAccepted, registered
 		);
 	}
 
@@ -99,7 +99,7 @@ public final class ValidatorDTO {
 			&& name.equals(that.name)
 			&& infoURL.equals(that.infoURL)
 			&& totalDelegatedStake.equals(that.totalDelegatedStake)
-			&& percentage == that.percentage
+			&& Double.compare(that.validatorFee, validatorFee) == 0
 			&& ownerDelegation.equals(that.ownerDelegation);
 	}
 
@@ -107,7 +107,7 @@ public final class ValidatorDTO {
 	public int hashCode() {
 		return Objects.hash(
 			address, ownerAddress, name, infoURL, totalDelegatedStake,
-			ownerDelegation, percentage, isExternalStakeAccepted, registered
+			ownerDelegation, validatorFee, isExternalStakeAccepted, registered
 		);
 	}
 
@@ -120,7 +120,7 @@ public final class ValidatorDTO {
 			+ ", infoURL='" + infoURL + '\''
 			+ ", totalDelegatedStake=" + totalDelegatedStake
 			+ ", ownerDelegation=" + ownerDelegation
-			+ ", percentage=" + percentage
+			+ ", validatorFee=" + validatorFee
 			+ ", isExternalStakeAccepted=" + isExternalStakeAccepted
 			+ ", registered=" + registered
 			+ ')';
@@ -154,8 +154,8 @@ public final class ValidatorDTO {
 		return isExternalStakeAccepted;
 	}
 
-	public long getPercentage() {
-		return percentage;
+	public double getValidatorFee() {
+		return validatorFee;
 	}
 
 	public boolean isRegistered() {

--- a/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/async/AsyncRadixApiCreationTest.java
+++ b/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/async/AsyncRadixApiCreationTest.java
@@ -42,7 +42,6 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -50,6 +49,7 @@ import static org.mockito.Mockito.when;
 
 import static com.radixdlt.client.lib.api.token.Amount.amount;
 
+//TODO: test remaining actions!!!
 public class AsyncRadixApiCreationTest {
 	private static final String BASE_URL = "http://localhost/";
 	public static final ECKeyPair KEY_PAIR1 = keyPairOf(1);
@@ -157,20 +157,21 @@ public class AsyncRadixApiCreationTest {
 			.onFailure(failure -> fail(failure.toString()))
 			.onSuccess(client -> client.transaction().build(request).join()
 				.onFailure(failure -> fail(failure.toString()))
-				.onSuccess(builtTransactionDTO -> assertEquals(amount(73800).micros(), builtTransactionDTO.getFee()))
-				.map(builtTransactionDTO -> builtTransactionDTO.toFinalized(KEY_PAIR1))
-				.onSuccess(finalizedTransaction -> client.transaction().finalize(finalizedTransaction, false).join()
-					.onSuccess(txDTO -> assertNotNull(txDTO.getTxId()))
-					.onSuccess(submittableTransaction -> client.transaction().submit(submittableTransaction).join()
-						.onFailure(failure -> fail(failure.toString()))
-						.onSuccess(txDTO -> assertEquals(submittableTransaction.getTxId(), txDTO.getTxId())))));
+				.onSuccess(builtTransaction -> assertEquals(amount(73800).micros(), builtTransaction.getFee()))
+				.map(builtTransaction -> builtTransaction.toFinalized(KEY_PAIR1))
+				.onSuccess(finalizedTransaction -> client.transaction().finalize(finalizedTransaction, true).join()
+					.onFailure(failure -> fail(failure.toString()))));
 	}
 
 	@Test
 	@Ignore
+	//TODO: for some reason operation succeeds only if transaction contains only one action
 	public void testRegisterValidator() {
 		var request = TransactionRequest.createBuilder(ACCOUNT_ADDRESS3)
 			.registerValidator(VALIDATOR_ADDRESS, Optional.of("MyValidator"), Optional.of("http://my.validator.url.com/"))
+			.updateValidatorFee(VALIDATOR_ADDRESS, 3.1)
+			.updateValidatorOwner(VALIDATOR_ADDRESS, ACCOUNT_ADDRESS3)
+			.updateValidatorAllowDelegationFlag(VALIDATOR_ADDRESS, true)
 			.build();
 
 		RadixApi.connect(BASE_URL)
@@ -178,13 +179,10 @@ public class AsyncRadixApiCreationTest {
 			.onFailure(failure -> fail(failure.toString()))
 			.onSuccess(client -> client.transaction().build(request)
 				.onFailure(failure -> fail(failure.toString()))
-				.onSuccess(builtTransactionDTO -> assertEquals(UInt256.from(100000000000000000L), builtTransactionDTO.getFee()))
-				.map(builtTransactionDTO -> builtTransactionDTO.toFinalized(KEY_PAIR3))
-				.onSuccess(finalizedTransaction -> client.transaction().finalize(finalizedTransaction, false)
-					.onSuccess(txDTO -> assertNotNull(txDTO.getTxId()))
-					.onSuccess(submittableTransaction -> client.transaction().submit(submittableTransaction)
-						.onFailure(failure -> fail(failure.toString()))
-						.onSuccess(txDTO -> assertEquals(submittableTransaction.getTxId(), txDTO.getTxId())))));
+				.onSuccess(builtTransaction -> assertEquals(amount(102600).micros(), builtTransaction.getFee()))
+				.map(builtTransaction -> builtTransaction.toFinalized(KEY_PAIR3))
+				.onSuccess(finalizedTransaction -> client.transaction().finalize(finalizedTransaction, true).join()
+					.onFailure(failure -> fail(failure.toString()))));
 	}
 
 	private TxBlobDTO buildBlobDto() {
@@ -193,9 +191,9 @@ public class AsyncRadixApiCreationTest {
 
 	private FinalizedTransaction buildFinalizedTransaction() throws PublicKeyException {
 		var sig = ECDSASignature.decodeFromHexDer(SIG);
-		var pubkey = ECPublicKey.fromHex(PUB_KEY);
-		var blobDTO = buildBlobDto();
-		return FinalizedTransaction.create(blobDTO.getBlob(), sig, pubkey, blobDTO.getTxId());
+		var publicKey = ECPublicKey.fromHex(PUB_KEY);
+		var blob = buildBlobDto();
+		return FinalizedTransaction.create(blob.getBlob(), sig, publicKey, blob.getTxId());
 	}
 
 	private Promise<RadixApi> prepareClient(String responseBody) throws IOException {

--- a/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiLocalTest.java
+++ b/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiLocalTest.java
@@ -57,11 +57,15 @@ public class SyncRadixApiLocalTest {
 		+ "addup7z2zfm4c3jqurkgjv\",\"balance\":{\"stakes\":[{\"delegate\":\"dv1qgcwgzawsygqxe4xklx94quptdlq302330m690"
 		+ "tt0q0sjsjwawyvs6zsklj\",\"amount\":\"1000000000000000000000000000\"}],\"tokens\":[]}},\"id\":\"2\",\"jsonrp"
 		+ "c\":\"2.0\"}\n";
-	private static final String VALIDATOR_INFO = "{\"result\":{\"owner\":\"ddx1qsprpeqt46q3qqmx56muck5rs9dhuz9a2x9l0g4"
-		+ "addup7z2zfm4c3jqurkgjv\",\"validatorFee\":0,\"address\":\"dv1qgcwgzawsygqxe4xklx94quptdlq302330m690tt0q0s"
-		+ "jsjwawyvs6zsklj\",\"stakes\":[{\"amount\":\"1000000000000000000000000000\",\"delegator\":\"ddx1qsprpeqt46q3"
-		+ "qqmx56muck5rs9dhuz9a2x9l0g4addup7z2zfm4c3jqurkgjv\"}],\"allowDelegation\":true,\"name\":\"\",\"registered\""
-		+ ":true,\"totalStake\":\"1000000000000000000000000000\",\"url\":\"\"},\"id\":\"2\",\"jsonrpc\":\"2.0\"}\n";
+	private static final String VALIDATOR_INFO = "{\"result\":{\"owner\":"
+		+ "\"ddx1qspll7tm6464am4yypzn59p42g6a8qhkguhc269p3vhs27s5vq5h24sfvvdfj\","
+		+ "\"address\":\"dv1q0llj774w40wafpqg5apgd2jxhfc9aj897zk3gvt9uzh59rq9964vjryzf9\","
+		+ "\"stakes\":[{\"amount\":\"100000000000000000000\",\"delegator\":"
+		+ "\"ddx1qspzsu73jt6ps6g8l0rj2yya2euunqapv7j2qemgaaujyej2tlp3lcs99m6k9\"},"
+		+ "{\"amount\":\"5300000000000000000000000\",\"delegator\":"
+		+ "\"ddx1qspll7tm6464am4yypzn59p42g6a8qhkguhc269p3vhs27s5vq5h24sfvvdfj\"}],"
+		+ "\"allowDelegation\":true,\"name\":\"\",\"validatorFee\":0,\"registered\":true,"
+		+ "\"totalStake\":\"5300100000000000000000000\",\"url\":\"\"},\"id\":\"2\",\"jsonrpc\":\"2.0\"}\n";
 	private static final String NEXT_EPOCH = "{\"result\":{\"validators\":[{\"totalDelegatedStake\":\"1000000000000000"
 		+ "000000000000\",\"validatorFee\":0,\"address\":\"dv1qtjlayqkvk234cwh5rs72uunjwgte8gnr4gp6vvgqmmdjl9fjvr5ul"
 		+ "nv4zg\",\"infoURL\":\"\",\"ownerDelegation\":\"1000000000000000000000000000\",\"name\":\"\",\"registered\":"
@@ -117,7 +121,7 @@ public class SyncRadixApiLocalTest {
 			.onFailure(failure -> fail(failure.toString()))
 			.onSuccess(client -> client.local().validatorInfo()
 				.onFailure(failure -> fail(failure.toString()))
-				.onSuccess(localValidatorInfo -> assertEquals(1, localValidatorInfo.getStakes().size()))
+				.onSuccess(localValidatorInfo -> assertEquals(2, localValidatorInfo.getStakes().size()))
 				.onSuccess(localValidatorInfo -> assertTrue(localValidatorInfo.isRegistered())));
 	}
 

--- a/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiValidatorTest.java
+++ b/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiValidatorTest.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 
 import com.radixdlt.client.lib.api.ValidatorAddress;
 import com.radixdlt.networks.Addressing;
-import com.radixdlt.utils.UInt256;
 import com.radixdlt.utils.functional.Result;
 
 import java.net.http.HttpClient;
@@ -33,6 +32,8 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import static com.radixdlt.client.lib.api.token.Amount.amount;
 
 public class SyncRadixApiValidatorTest {
 	private static final String BASE_URL = "http://localhost/";
@@ -47,10 +48,11 @@ public class SyncRadixApiValidatorTest {
 		+ ",\"name\":\"\",\"registered\":true,\"ownerAddress\":\"ddx1qspll7tm6464am4yypzn59p42g6a8qhkguhc269p3vhs27s5vq5h24sfvvdfj\""
 		+ ",\"isExternalStakeAccepted\":true}]},\"id\":\"2\",\"jsonrpc\":\"2.0\"}\n";
 
-	private static final String LOOKUP = "{\"result\":{\"totalDelegatedStake\":\"4754240000000000000000000\",\"validatorFee\":0,\""
-		+ "address\":\"dv1q0llj774w40wafpqg5apgd2jxhfc9aj897zk3gvt9uzh59rq9964vjryzf9\",\"infoURL\":\"\",\"ownerDelegation\":\"10000"
-		+ "0000000000000000\",\"name\":\"\",\"registered\":true,\"ownerAddress\":\"ddx1qspll7tm6464am4yypzn59p42g6a8qhkguhc269p3vhs2"
-		+ "7s5vq5h24sfvvdfj\",\"isExternalStakeAccepted\":true},\"id\":\"2\",\"jsonrpc\":\"2.0\"}\n";
+	private static final String LOOKUP = "{\"result\":{\"totalDelegatedStake\":\"4900100000000000000000000\","
+		+ "\"address\":\"dv1q0llj774w40wafpqg5apgd2jxhfc9aj897zk3gvt9uzh59rq9964vjryzf9\",\"infoURL\":\"\","
+		+ "\"ownerDelegation\":\"4900100000000000000000000\",\"name\":\"\",\"validatorFee\":0,"
+		+ "\"registered\":true,\"ownerAddress\":\"ddx1qspll7tm6464am4yypzn59p42g6a8qhkguhc269p3vhs27s5vq5h24sfvvdfj\","
+		+ "\"isExternalStakeAccepted\":true},\"id\":\"2\",\"jsonrpc\":\"2.0\"}\n";
 
 	private final HttpClient client = mock(HttpClient.class);
 
@@ -67,7 +69,6 @@ public class SyncRadixApiValidatorTest {
 
 	@Test
 	public void testLookup() throws Exception {
-		var stake = UInt256.from("4754240000000000000000000");
 		var address = ValidatorAddress.of(Addressing.ofNetworkId(99).forValidators()
 			.parse("dv1q0llj774w40wafpqg5apgd2jxhfc9aj897zk3gvt9uzh59rq9964vjryzf9"));
 
@@ -78,7 +79,7 @@ public class SyncRadixApiValidatorTest {
 				client -> client.validator().lookup(address)
 					.onFailure(failure -> fail(failure.toString()))
 					.onSuccess(validatorDTO -> assertTrue(validatorDTO.isExternalStakeAccepted()))
-					.onSuccess(validatorDTO -> assertEquals(stake, validatorDTO.getTotalDelegatedStake())));
+					.onSuccess(validatorDTO -> assertEquals(amount(4900100).tokens(), validatorDTO.getTotalDelegatedStake())));
 	}
 
 	private Result<RadixApi> prepareClient(String responseBody) throws Exception {


### PR DESCRIPTION
Changes summary:
- Renamed action to `UpdateValidatorFee`
- Fixed/added validator-related actions to client
- Fixed `UpdateValidatorFee` parameter to have "float" type