### PR TITLE
Rename action from `UpdateValidator` to `UpdateValidatorMetadata`

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/ActionType.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/ActionType.java
@@ -36,7 +36,7 @@ public enum ActionType {
 	MINT("MintTokens"),
 	REGISTER_VALIDATOR("RegisterValidator"),
 	UNREGISTER_VALIDATOR("UnregisterValidator"),
-	UPDATE_VALIDATOR("UpdateValidator"),
+	UPDATE_VALIDATOR_METADATA("UpdateValidatorMetadata"),
 	UPDATE_VALIDATOR_FEE("UpdateValidatorFee"),
 	UPDATE_OWNER("UpdateValidatorOwnerAddress"),
 	UPDATE_DELEGATION("UpdateAllowDelegationFlag"),

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/action/TransactionAction.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/action/TransactionAction.java
@@ -56,8 +56,8 @@ public interface TransactionAction {
 		return new UnregisterValidatorAction(validatorKey);
 	}
 
-	static TransactionAction update(ECPublicKey validatorKey, Optional<String> name, Optional<String> url) {
-		return new UpdateValidatorAction(validatorKey, name.orElse(null), url.orElse(null));
+	static TransactionAction updateMetadata(ECPublicKey validatorKey, Optional<String> name, Optional<String> url) {
+		return new UpdateValidatorMetadataAction(validatorKey, name.orElse(null), url.orElse(null));
 	}
 
 	static TransactionAction updateValidatorFee(ECPublicKey validatorKey, int percentage) {

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/action/UpdateValidatorMetadataAction.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/data/action/UpdateValidatorMetadataAction.java
@@ -15,22 +15,27 @@
  * language governing permissions and limitations under the License.
  */
 
-package com.radixdlt.client.lib.api.action;
+package com.radixdlt.api.data.action;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.radixdlt.client.lib.api.ActionType;
-import com.radixdlt.client.lib.api.ValidatorAddress;
+import com.radixdlt.atom.TxAction;
+import com.radixdlt.atom.actions.UpdateValidatorMetadata;
+import com.radixdlt.crypto.ECPublicKey;
 
-@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-public class UpdateValidatorAction implements Action {
-	private final ActionType type = ActionType.UPDATE_VALIDATOR;
-	private final ValidatorAddress delegate;
+import java.util.stream.Stream;
+
+class UpdateValidatorMetadataAction implements TransactionAction {
+	private final ECPublicKey validatorKey;
 	private final String name;
 	private final String url;
 
-	public UpdateValidatorAction(ValidatorAddress delegate, String name, String url) {
-		this.delegate = delegate;
+	UpdateValidatorMetadataAction(ECPublicKey validatorKey, String name, String url) {
+		this.validatorKey = validatorKey;
 		this.name = name;
 		this.url = url;
+	}
+
+	@Override
+	public Stream<TxAction> toAction() {
+		return Stream.of(new UpdateValidatorMetadata(validatorKey, name, url));
 	}
 }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/ActionParserService.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/ActionParserService.java
@@ -131,12 +131,12 @@ public final class ActionParserService {
 					validator(element)
 				).map(TransactionAction::unregister);
 
-			case UPDATE_VALIDATOR:
+			case UPDATE_VALIDATOR_METADATA:
 				return allOf(
 					validator(element),
 					optionalName(element),
 					optionalUrl(element)
-				).map(TransactionAction::update);
+				).map(TransactionAction::updateMetadata);
 
 			case UPDATE_VALIDATOR_FEE:
 				return allOf(

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/reducer/AllValidatorsReducer.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/reducer/AllValidatorsReducer.java
@@ -53,7 +53,7 @@ public final class AllValidatorsReducer {
 		return (prev, p) -> {
 			if (p instanceof ValidatorRegisteredCopy) {
 				var v = (ValidatorRegisteredCopy) p;
-				return prev.add(v.getValidatorKey());
+				return prev.setRegistered(v.getValidatorKey(), v.isRegistered());
 			} else if (p instanceof ValidatorMetaData) {
 				var s = (ValidatorMetaData) p;
 				return prev.set(s);

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/api/service/ActionParserServiceTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/api/service/ActionParserServiceTest.java
@@ -259,11 +259,11 @@ public class ActionParserServiceTest {
 	}
 
 	@Test
-	public void updateValidatorIsParsedCorrectlyWithUrlAndName() {
+	public void updateValidatorMetadataIsParsedCorrectlyWithUrlAndName() {
 		var key = ECKeyPair.generateNew().getPublicKey();
 		var validatorAddr = addressing.forValidators().of(key);
 
-		var source = "[{\"type\":\"UpdateValidator\", \"validator\":\"%s\", \"name\":\"%s\", \"url\":\"%s\"}]";
+		var source = "[{\"type\":\"UpdateValidatorMetadata\", \"validator\":\"%s\", \"name\":\"%s\", \"url\":\"%s\"}]";
 		var actions = jsonArray(String.format(source, validatorAddr, "validator 1", "http://localhost/"));
 
 		actionParserService.parse(actions)
@@ -286,11 +286,11 @@ public class ActionParserServiceTest {
 	}
 
 	@Test
-	public void updateValidatorIsParsedCorrectlyWithUrl() {
+	public void updateValidatorMetadataIsParsedCorrectlyWithUrl() {
 		var key = ECKeyPair.generateNew().getPublicKey();
 		var validatorAddr = addressing.forValidators().of(key);
 
-		var source = "[{\"type\":\"UpdateValidator\", \"validator\":\"%s\", \"url\":\"%s\"}]";
+		var source = "[{\"type\":\"UpdateValidatorMetadata\", \"validator\":\"%s\", \"url\":\"%s\"}]";
 		var actions = jsonArray(String.format(source, validatorAddr, "http://localhost/"));
 
 		actionParserService.parse(actions)
@@ -313,11 +313,11 @@ public class ActionParserServiceTest {
 	}
 
 	@Test
-	public void updateValidatorIsParsedCorrectly() {
+	public void updateValidatorMetadataIsParsedCorrectly() {
 		var key = ECKeyPair.generateNew().getPublicKey();
 		var validatorAddr = addressing.forValidators().of(key);
 
-		var source = "[{\"type\":\"UpdateValidator\", \"validator\":\"%s\"}]";
+		var source = "[{\"type\":\"UpdateValidatorMetadata\", \"validator\":\"%s\"}]";
 		var actions = jsonArray(String.format(source, validatorAddr));
 
 		actionParserService.parse(actions)

--- a/radixdlt-java-common/src/main/java/com/radixdlt/utils/functional/FunctionalUtils.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/utils/functional/FunctionalUtils.java
@@ -19,10 +19,14 @@ package com.radixdlt.utils.functional;
 
 import com.google.common.collect.ImmutableMap;
 
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public interface FunctionalUtils {
@@ -96,5 +100,59 @@ public interface FunctionalUtils {
 		return existingMap.entrySet().stream()
 			.filter(e -> !keyToRemove.equals(e.getKey()))
 			.collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+	}
+
+	/**
+	 * Return copy of the input set with specified element removed.
+	 *
+	 * @param element element to remove
+	 * @param input input set
+	 *
+	 * @return new set with specified element removed
+	 */
+	static <T> Set<T> removeElement(T element, Set<T> input) {
+		return input.stream().filter(e -> !e.equals(element)).collect(Collectors.toSet());
+	}
+
+	/**
+	 * Return copy of the input set with provided element added.
+	 *
+	 * @param element element to add
+	 * @param input input set
+	 *
+	 * @return new set with provided element added
+	 */
+	static <T> Set<T> addElement(T element, Set<T> input) {
+		return Stream.concat(input.stream(), Stream.of(element)).collect(Collectors.toSet());
+	}
+
+	/**
+	 * Merge several sets into one.
+	 *
+	 * @param inputs sets to merge
+	 *
+	 * @return merged set
+	 */
+	@SafeVarargs
+	static <T> Set<T> mergeAll(Set<T>... inputs) {
+		var output = new HashSet<T>();
+
+		for (var input : inputs) {
+			output.addAll(input);
+		}
+
+		return Set.copyOf(output);
+	}
+
+	/**
+	 * Create new immutable map entry.
+	 *
+	 * @param key entry key
+	 * @param value entry value
+	 *
+	 * @return created entry
+	 */
+	static <K, V> Map.Entry<K, V> newEntry(K key, V value) {
+		return new SimpleImmutableEntry<>(key, value);
 	}
 }

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/ActionType.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/ActionType.java
@@ -34,7 +34,7 @@ public enum ActionType {
 	MINT("MintTokens"),
 	REGISTER_VALIDATOR("RegisterValidator"),
 	UNREGISTER_VALIDATOR("UnregisterValidator"),
-	UPDATE_VALIDATOR("UpdateValidator"),
+	UPDATE_VALIDATOR_METADATA("UpdateValidatorMetadata"),
 	UPDATE_VALIDATOR_FEE("UpdateValidatorFee"),
 	UPDATE_VALIDATOR_OWNER("UpdateValidatorOwnerAddress"),
 	UPDATE_VALIDATOR_DELEGATION_FLAG("UpdateAllowDelegationFlag"),

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/TransactionRequest.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/TransactionRequest.java
@@ -28,7 +28,7 @@ import com.radixdlt.client.lib.api.action.StakeAction;
 import com.radixdlt.client.lib.api.action.TransferAction;
 import com.radixdlt.client.lib.api.action.UnregisterValidatorAction;
 import com.radixdlt.client.lib.api.action.UnstakeAction;
-import com.radixdlt.client.lib.api.action.UpdateValidatorAction;
+import com.radixdlt.client.lib.api.action.UpdateValidatorMetadataAction;
 import com.radixdlt.client.lib.api.action.UpdateValidatorAllowDelegationFlagAction;
 import com.radixdlt.client.lib.api.action.UpdateValidatorFeeAction;
 import com.radixdlt.client.lib.api.action.UpdateValidatorOwnerAction;
@@ -123,8 +123,8 @@ public class TransactionRequest {
 			return this;
 		}
 
-		public TransactionRequestBuilder updateValidator(ValidatorAddress validator, Optional<String> name, Optional<String> url) {
-			actions.add(new UpdateValidatorAction(validator, name.orElse(null), url.orElse(null)));
+		public TransactionRequestBuilder updateValidatorMetadata(ValidatorAddress validator, Optional<String> name, Optional<String> url) {
+			actions.add(new UpdateValidatorMetadataAction(validator, name.orElse(null), url.orElse(null)));
 			return this;
 		}
 

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/action/UpdateValidatorMetadataAction.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/action/UpdateValidatorMetadataAction.java
@@ -15,27 +15,22 @@
  * language governing permissions and limitations under the License.
  */
 
-package com.radixdlt.api.data.action;
+package com.radixdlt.client.lib.api.action;
 
-import com.radixdlt.atom.TxAction;
-import com.radixdlt.atom.actions.UpdateValidatorMetadata;
-import com.radixdlt.crypto.ECPublicKey;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.radixdlt.client.lib.api.ActionType;
+import com.radixdlt.client.lib.api.ValidatorAddress;
 
-import java.util.stream.Stream;
-
-class UpdateValidatorAction implements TransactionAction {
-	private final ECPublicKey validatorKey;
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class UpdateValidatorMetadataAction implements Action {
+	private final ActionType type = ActionType.UPDATE_VALIDATOR_METADATA;
+	private final ValidatorAddress delegate;
 	private final String name;
 	private final String url;
 
-	UpdateValidatorAction(ECPublicKey validatorKey, String name, String url) {
-		this.validatorKey = validatorKey;
+	public UpdateValidatorMetadataAction(ValidatorAddress delegate, String name, String url) {
+		this.delegate = delegate;
 		this.name = name;
 		this.url = url;
-	}
-
-	@Override
-	public Stream<TxAction> toAction() {
-		return Stream.of(new UpdateValidatorMetadata(validatorKey, name, url));
 	}
 }


### PR DESCRIPTION
Changes summary:
- Renamed action from `UpdateValidator` to `UpdateValidatorMetadata`, updated accordingly related classes/methods
- Fixed validator unregistration handling while collecting validator info
