### PR TITLE
Docker config fix for acceptance tests

### DIFF
--- a/radixdlt-regression/src/test/java/com/radix/acceptance/transaction_lookup/TransactionLookup.java
+++ b/radixdlt-regression/src/test/java/com/radix/acceptance/transaction_lookup/TransactionLookup.java
@@ -67,7 +67,7 @@ public class TransactionLookup extends AcceptanceTest {
         var history = new AtomicReference<TransactionHistory>();
         await().until(() -> {
             var historyBuffer = account1.account().history(account1.getAddress(), 100, NavigationCursor.create(""));
-            if (historyBuffer.getTransactions().size() >= 5) {
+            if (historyBuffer.getTransactions().size() >= 6) {
                 history.set(historyBuffer);
                 return true;
             }

--- a/radixdlt-regression/src/test/java/com/radix/test/docker/DockerClient.java
+++ b/radixdlt-regression/src/test/java/com/radix/test/docker/DockerClient.java
@@ -15,4 +15,5 @@ public interface DockerClient {
     void connect();
 
     String runShellCommandAndGetOutput(String containerId, String... commands);
+
 }

--- a/radixdlt-regression/src/test/java/com/radix/test/docker/LocalDockerClient.java
+++ b/radixdlt-regression/src/test/java/com/radix/test/docker/LocalDockerClient.java
@@ -37,12 +37,6 @@ public class LocalDockerClient implements DockerClient {
         dockerClient.pingCmd().exec();
     }
 
-    public void printAllContainers() {
-        dockerClient.listContainersCmd().withShowAll(true).exec().forEach(container -> {
-            logger.info(container.toString());
-        });
-    }
-
     public String runShellCommandAndGetOutput(String containerId, String... commands) {
         var output = new ByteArrayOutputStream();
         var error = new ByteArrayOutputStream();

--- a/radixdlt-regression/src/test/java/com/radix/test/docker/LocalDockerClient.java
+++ b/radixdlt-regression/src/test/java/com/radix/test/docker/LocalDockerClient.java
@@ -37,6 +37,12 @@ public class LocalDockerClient implements DockerClient {
         dockerClient.pingCmd().exec();
     }
 
+    public void printAllContainers() {
+        dockerClient.listContainersCmd().withShowAll(true).exec().forEach(container -> {
+            logger.info(container.toString());
+        });
+    }
+
     public String runShellCommandAndGetOutput(String containerId, String... commands) {
         var output = new ByteArrayOutputStream();
         var error = new ByteArrayOutputStream();

--- a/radixdlt-regression/src/test/java/com/radix/test/network/DockerConfiguration.java
+++ b/radixdlt-regression/src/test/java/com/radix/test/network/DockerConfiguration.java
@@ -8,18 +8,27 @@ import com.radix.test.Utils;
 public class DockerConfiguration {
 
     private final String socketUrl;
+    private String containerName;
 
-    private DockerConfiguration(String socketUrl) {
+    private DockerConfiguration(String socketUrl, String containerName) {
         this.socketUrl = socketUrl;
+        this.containerName = containerName;
     }
 
     public static DockerConfiguration fromEnv() {
         var socketUrl = Utils.getEnvWithDefault("RADIXDLT_DOCKER_SOCKET_URL", "unix:///var/run/docker.sock");
-        return new DockerConfiguration(socketUrl);
+        var containerName = Utils.getEnvWithDefault("RADIXDLT_DOCKER_CONTAINER_NAME", "docker_core%d_1");
+        if (!containerName.contains("%d")) {
+            throw new RuntimeException("Docker container name needs to contain a '%d' wildcard e.g. docker_core%d_1");
+        }
+        return new DockerConfiguration(socketUrl, containerName);
     }
 
     public String getSocketUrl() {
         return socketUrl;
     }
 
+    public String getContainerName() {
+        return containerName;
+    }
 }

--- a/radixdlt-regression/src/test/java/com/radix/test/network/RadixNetworkNodeLocator.java
+++ b/radixdlt-regression/src/test/java/com/radix/test/network/RadixNetworkNodeLocator.java
@@ -1,7 +1,6 @@
 package com.radix.test.network;
 
 import com.radix.test.docker.DockerClient;
-import com.radix.test.docker.LocalDockerClient;
 import com.radix.test.network.client.RadixHttpClient;
 import com.radixdlt.application.system.construction.FeeReserveNotEnoughBalanceException;
 import com.radixdlt.client.lib.api.AccountAddress;
@@ -31,7 +30,6 @@ public class RadixNetworkNodeLocator {
 
     public static List<RadixNode> locateNodes(RadixNetworkConfiguration configuration, RadixHttpClient httpClient,
                                               DockerClient dockerClient) {
-        ((LocalDockerClient) dockerClient).printAllContainers();
         var peers = configuration.connect().network().peers();
         var peersSizePlusOne = peers.size() + 1;
         switch (configuration.getType()) {
@@ -58,9 +56,10 @@ public class RadixNetworkNodeLocator {
     }
 
     /**
-     * TODO explain
+     * Tries to figure out which endpoints are available (e.g. /account, /construction) and also tries to use the
+     * docker client to establish a connection to this node's container.
      * <p>
-     * TODO handle exceptions be    tter. Right now, the test will fail is anything goes wrong here
+     * TODO handle exceptions better. Right now, the test will fail is anything goes wrong here
      */
     private static RadixNode figureOutNode(String jsonRpcRootUrl, int primaryPort, int secondaryPort,
                                            String expectedContainerName, RadixHttpClient httpClient, DockerClient dockerClient) {


### PR DESCRIPTION
Externalized the docker container name property, so that Jenkins can set it.

Proof that this works: https://jenkins-preprod.radixdlt.com/job/RC-Branch/job/acceptance-tests/1200/testReport/(root)/