### PR TITLE
Fix reporting of active endpoints

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/EndpointConfig.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/EndpointConfig.java
@@ -66,6 +66,7 @@ package com.radixdlt;
 
 import com.radixdlt.networks.Network;
 import com.radixdlt.api.module.DeveloperEndpointModule;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -86,6 +87,7 @@ import com.radixdlt.properties.RuntimeProperties;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.radixdlt.EndpointConfig.Environment.ALL;
 import static com.radixdlt.EndpointConfig.Environment.DEV_ONLY;
@@ -192,7 +194,7 @@ public final class EndpointConfig {
 	}
 
 	public static List<EndpointStatus> endpointStatuses(RuntimeProperties properties, int networkId) {
-		return NODE_ENDPOINTS.stream()
+		return Stream.concat(NODE_ENDPOINTS.stream(), ARCHIVE_ENDPOINTS.stream())
 			.map(e -> EndpointStatus.create(e.name, isEnabled(e, properties, networkId)))
 			.collect(Collectors.toList());
 	}

--- a/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiApiTest.java
+++ b/radixdlt-java/radixdlt-java/src/test/java/com/radixdlt/client/lib/api/sync/SyncRadixApiApiTest.java
@@ -81,9 +81,9 @@ public class SyncRadixApiApiTest {
 	private static final String BASE_URL = "http://localhost/";
 
 	private static final String NETWORK_ID = "{\"result\":{\"networkId\":99},\"id\":\"1\",\"jsonrpc\":\"2.0\"}";
-	private static final String CONFIGURATION = "{\"result\":{\"endpoints\":[\"/metrics\",\"/system\",\"/account\","
-		+ "\"/validation\",\"/universe\",\"/faucet\",\"/chaos\",\"/health\",\"/version\",\"/developer\"]},\"id\":"
-		+ "\"2\",\"jsonrpc\":\"2.0\"}\n";
+	private static final String CONFIGURATION = "{\"result\":{\"endpoints\":[\"/metrics\",\"/system\","
+		+ "\"/account\",\"/validation\",\"/universe\",\"/faucet\",\"/chaos\",\"/health\",\"/version\","
+		+ "\"/developer\",\"/archive\",\"/construction\"]},\"id\":\"2\",\"jsonrpc\":\"2.0\"}\n";
 	private static final String DATA = "{\"result\":{\"elapsed\":{\"apidb\":{\"balance\":{\"read\":1672,\""
 		+ "write\":4790},\"flush\":{\"time\":630722},\"transaction\":{\"read\":0,\"write\":1453},\"token\":"
 		+ "{\"read\":134,\"write\":842}}},\"count\":{\"apidb\":{\"flush\":{\"count\":1627},\"balance\":{\"t"
@@ -101,7 +101,7 @@ public class SyncRadixApiApiTest {
 			.onFailure(failure -> fail(failure.toString()))
 			.onSuccess(client -> client.api().configuration()
 				.onFailure(failure -> fail(failure.toString()))
-				.onSuccess(configurationDTO -> assertEquals(10, configurationDTO.getEndpoints().size())));
+				.onSuccess(configurationDTO -> assertEquals(12, configurationDTO.getEndpoints().size())));
 	}
 
 	@Test


### PR DESCRIPTION
Changes summary:
- Addresses [bug](https://radixdlt.atlassian.net/browse/RPNV1-1427): the `api.get_configuration` API method does not show `/archive` and `/construction` endpoints as active even if they are enabled.