### PR TITLE
Remove docker-compose files from release

### DIFF
--- a/.github/workflows/add-artifacts-to-release.yml
+++ b/.github/workflows/add-artifacts-to-release.yml
@@ -61,26 +61,3 @@ jobs:
           asset_path: ./radixdlt-core/radixdlt/build/distributions/radixdlt-${{ steps.get_version.outputs.radixdlt_version }}.zip
           asset_name: radixdlt-dist-${{ steps.get_version.outputs.radixdlt_version }}.zip
           asset_content_type: application/zip
-      - uses: actions/checkout@v2
-        with:
-          repository: radixdlt/radixdlt-iac
-          ref: master
-          token: ${{ secrets.RADIXBOT_GITHUB_REPO_PACKAGES_TOKEN }}
-      - name: Upload radix-archivenode-compose.yml
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./projects/release-ymls/radix-archivenode-compose.yml
-          asset_name: radix-archivenode-compose.yml
-          asset_content_type: application/json
-      - name: Upload radix-fullnode-compose.yml
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./projects/release-ymls/radix-fullnode-compose.yml
-          asset_name: radix-fullnode-compose.yml
-          asset_content_type: application/json


### PR DESCRIPTION
docker-compose files have been moved now to the [node-runner](https://github.com/radixdlt/node-runner) repository