### PR TITLE
Blacklist uri on failed p2p handshake

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/SystemConfigService.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/service/SystemConfigService.java
@@ -463,7 +463,9 @@ public class SystemConfigService {
 		final var knownAddressesArray = jsonArray();
 
 		e.getKnownAddresses().forEach(addr -> {
-			final var addrObj = jsonObject().put("uri", addr.getUri());
+			final var addrObj = jsonObject()
+				.put("uri", addr.getUri())
+				.put("blacklisted", addr.blacklisted());
 			addr.getLastSuccessfulConnection().ifPresent(ts -> addrObj.put("lastSuccessfulConnection", ts));
 			knownAddressesArray.put(addrObj);
 		});

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerEvent.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerEvent.java
@@ -206,15 +206,15 @@ public interface PeerEvent {
 		}
 	}
 
-	final class PeerConnectionFailed implements PeerEvent {
+	final class PeerHandshakeFailed implements PeerEvent {
 
 		private final RadixNodeUri uri;
 
-		public static PeerConnectionFailed create(RadixNodeUri uri) {
-			return new PeerConnectionFailed(uri);
+		public static PeerHandshakeFailed create(RadixNodeUri uri) {
+			return new PeerHandshakeFailed(uri);
 		}
 
-		private PeerConnectionFailed(RadixNodeUri uri) {
+		private PeerHandshakeFailed(RadixNodeUri uri) {
 			this.uri = uri;
 		}
 
@@ -230,7 +230,7 @@ public interface PeerEvent {
 			if (o == null || getClass() != o.getClass()) {
 				return false;
 			}
-			final var that = (PeerConnectionFailed) o;
+			final var that = (PeerHandshakeFailed) o;
 			return Objects.equals(uri, that.uri);
 		}
 

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerManager.java
@@ -76,6 +76,7 @@ import com.radixdlt.network.p2p.addressbook.AddressBookEntry;
 import com.radixdlt.network.p2p.PeerEvent.PeerConnected;
 import com.radixdlt.network.p2p.PeerEvent.PeerDisconnected;
 import com.radixdlt.network.p2p.PeerEvent.PeerLostLiveness;
+import com.radixdlt.network.p2p.PeerEvent.PeerConnectionFailed;
 import com.radixdlt.network.p2p.PeerEvent.PeerBanned;
 import com.radixdlt.network.p2p.transport.PeerChannel;
 import com.radixdlt.utils.functional.Result;
@@ -211,6 +212,8 @@ public final class PeerManager {
 				this.handlePeerLostLiveness((PeerLostLiveness) peerEvent);
 			} else if (peerEvent instanceof PeerBanned) {
 				this.handlePeerBanned((PeerBanned) peerEvent);
+			} else if (peerEvent instanceof PeerConnectionFailed) {
+				this.handlePeerConnectionFailed((PeerConnectionFailed) peerEvent);
 			}
 		};
 	}
@@ -322,5 +325,9 @@ public final class PeerManager {
 				log.info("Closing channel to peer {} because peer has been banned", pc.getRemoteNodeId());
 				pc.disconnect();
 			});
+	}
+
+	private void handlePeerConnectionFailed(PeerConnectionFailed peerConnectionFailed) {
+		this.addressBook.get().blacklist(peerConnectionFailed.getUri());
 	}
 }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerManager.java
@@ -76,7 +76,7 @@ import com.radixdlt.network.p2p.addressbook.AddressBookEntry;
 import com.radixdlt.network.p2p.PeerEvent.PeerConnected;
 import com.radixdlt.network.p2p.PeerEvent.PeerDisconnected;
 import com.radixdlt.network.p2p.PeerEvent.PeerLostLiveness;
-import com.radixdlt.network.p2p.PeerEvent.PeerConnectionFailed;
+import com.radixdlt.network.p2p.PeerEvent.PeerHandshakeFailed;
 import com.radixdlt.network.p2p.PeerEvent.PeerBanned;
 import com.radixdlt.network.p2p.transport.PeerChannel;
 import com.radixdlt.utils.functional.Result;
@@ -212,8 +212,8 @@ public final class PeerManager {
 				this.handlePeerLostLiveness((PeerLostLiveness) peerEvent);
 			} else if (peerEvent instanceof PeerBanned) {
 				this.handlePeerBanned((PeerBanned) peerEvent);
-			} else if (peerEvent instanceof PeerConnectionFailed) {
-				this.handlePeerConnectionFailed((PeerConnectionFailed) peerEvent);
+			} else if (peerEvent instanceof PeerHandshakeFailed) {
+				this.handlePeerHandshakeFailed((PeerHandshakeFailed) peerEvent);
 			}
 		};
 	}
@@ -327,7 +327,7 @@ public final class PeerManager {
 			});
 	}
 
-	private void handlePeerConnectionFailed(PeerConnectionFailed peerConnectionFailed) {
-		this.addressBook.get().blacklist(peerConnectionFailed.getUri());
+	private void handlePeerHandshakeFailed(PeerHandshakeFailed peerHandshakeFailed) {
+		this.addressBook.get().blacklist(peerHandshakeFailed.getUri());
 	}
 }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PendingOutboundChannelsManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PendingOutboundChannelsManager.java
@@ -115,8 +115,8 @@ public final class PendingOutboundChannelsManager {
 		return peerEvent -> {
 			if (peerEvent instanceof PeerEvent.PeerConnected) {
 				this.handlePeerConnected((PeerEvent.PeerConnected) peerEvent);
-			} else if (peerEvent instanceof PeerEvent.PeerConnectionFailed) {
-				this.handlePeerConnectionFailed((PeerEvent.PeerConnectionFailed) peerEvent);
+			} else if (peerEvent instanceof PeerEvent.PeerHandshakeFailed) {
+				this.handlePeerHandshakeFailed((PeerEvent.PeerHandshakeFailed) peerEvent);
 			}
 		};
 	}
@@ -131,9 +131,9 @@ public final class PendingOutboundChannelsManager {
 		}
 	}
 
-	private void handlePeerConnectionFailed(PeerEvent.PeerConnectionFailed peerConnectionFailed) {
+	private void handlePeerHandshakeFailed(PeerEvent.PeerHandshakeFailed peerHandshakeFailed) {
 		synchronized (lock) {
-			final var maybeFuture = this.pendingChannels.remove(peerConnectionFailed.getUri().getNodeId());
+			final var maybeFuture = this.pendingChannels.remove(peerHandshakeFailed.getUri().getNodeId());
 			if (maybeFuture != null) {
 				maybeFuture.completeExceptionally(new IOException("Peer connection failed"));
 			}

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PendingOutboundChannelsManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PendingOutboundChannelsManager.java
@@ -115,6 +115,8 @@ public final class PendingOutboundChannelsManager {
 		return peerEvent -> {
 			if (peerEvent instanceof PeerEvent.PeerConnected) {
 				this.handlePeerConnected((PeerEvent.PeerConnected) peerEvent);
+			} else if (peerEvent instanceof PeerEvent.PeerConnectionFailed) {
+				this.handlePeerConnectionFailed((PeerEvent.PeerConnectionFailed) peerEvent);
 			}
 		};
 	}
@@ -125,6 +127,15 @@ public final class PendingOutboundChannelsManager {
 			final var maybeFuture = this.pendingChannels.remove(channel.getRemoteNodeId());
 			if (maybeFuture != null) {
 				maybeFuture.complete(channel);
+			}
+		}
+	}
+
+	private void handlePeerConnectionFailed(PeerEvent.PeerConnectionFailed peerConnectionFailed) {
+		synchronized (lock) {
+			final var maybeFuture = this.pendingChannels.remove(peerConnectionFailed.getUri().getNodeId());
+			if (maybeFuture != null) {
+				maybeFuture.completeExceptionally(new IOException("Peer connection failed"));
 			}
 		}
 	}

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBook.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBook.java
@@ -127,7 +127,9 @@ public final class AddressBook {
 						this.knownPeers.put(uri.getNodeId(), newEntry);
 						persistEntry(newEntry);
 					} else {
-						final var updatedEntry = maybeExistingEntry.addUriIfNotExists(uri);
+						final var updatedEntry = maybeExistingEntry
+							.cleanupExpiredBlacklsitedUris()
+							.addUriIfNotExists(uri);
 						if (!updatedEntry.equals(maybeExistingEntry)) {
 							this.knownPeers.put(uri.getNodeId(), updatedEntry);
 							persistEntry(updatedEntry);
@@ -162,7 +164,9 @@ public final class AddressBook {
 				this.knownPeers.put(radixNodeUri.getNodeId(), newEntry);
 				persistEntry(newEntry);
 			} else {
-				final var updatedEntry = maybeExistingEntry.withLastSuccessfulConnectionFor(radixNodeUri, Instant.now());
+				final var updatedEntry = maybeExistingEntry
+					.cleanupExpiredBlacklsitedUris()
+					.withLastSuccessfulConnectionFor(radixNodeUri, Instant.now());
 				this.knownPeers.put(radixNodeUri.getNodeId(), updatedEntry);
 				persistEntry(updatedEntry);
 			}
@@ -193,7 +197,9 @@ public final class AddressBook {
 				final var alreadyBanned = existingEntry.bannedUntil()
 					.filter(bu -> bu.isAfter(banUntil)).isPresent();
 				if (!alreadyBanned) {
-					final var updatedEntry = existingEntry.withBanUntil(banUntil);
+					final var updatedEntry = existingEntry
+						.cleanupExpiredBlacklsitedUris()
+						.withBanUntil(banUntil);
 					this.knownPeers.put(nodeId, updatedEntry);
 					this.persistEntry(updatedEntry);
 					this.peerEventDispatcher.dispatch(PeerBanned.create(nodeId));
@@ -221,7 +227,9 @@ public final class AddressBook {
 				this.knownPeers.put(uri.getNodeId(), newEntry);
 				persistEntry(newEntry);
 			} else {
-				final var updatedEntry = maybeExistingEntry.withBlacklistedUri(uri, blacklistUntil);
+				final var updatedEntry = maybeExistingEntry
+					.cleanupExpiredBlacklsitedUris()
+					.withBlacklistedUri(uri, blacklistUntil);
 				this.knownPeers.put(uri.getNodeId(), updatedEntry);
 				persistEntry(updatedEntry);
 			}

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBook.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBook.java
@@ -214,13 +214,14 @@ public final class AddressBook {
 
 	public void blacklist(RadixNodeUri uri) {
 		synchronized (lock) {
+			final var blacklistUntil = Instant.now().plus(Duration.ofHours(2));
 			final var maybeExistingEntry = this.knownPeers.get(uri.getNodeId());
 			if (maybeExistingEntry == null) {
-				final var newEntry = AddressBookEntry.createBlacklisted(uri);
+				final var newEntry = AddressBookEntry.createBlacklisted(uri, blacklistUntil);
 				this.knownPeers.put(uri.getNodeId(), newEntry);
 				persistEntry(newEntry);
 			} else {
-				final var updatedEntry = maybeExistingEntry.withBlacklistedUri(uri);
+				final var updatedEntry = maybeExistingEntry.withBlacklistedUri(uri, blacklistUntil);
 				this.knownPeers.put(uri.getNodeId(), updatedEntry);
 				persistEntry(updatedEntry);
 			}

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBookEntry.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBookEntry.java
@@ -245,6 +245,13 @@ public final class AddressBookEntry {
 		}
 	}
 
+	public AddressBookEntry cleanupExpiredBlacklsitedUris() {
+		final var newKnownAddresses = knownAddresses.stream()
+			.filter(not(PeerAddressEntry::blacklistExpired))
+			.collect(ImmutableSet.toImmutableSet());
+		return new AddressBookEntry(nodeId, bannedUntil, newKnownAddresses);
+	}
+
 	@Override
 	public String toString() {
 		return String.format(
@@ -314,6 +321,10 @@ public final class AddressBookEntry {
 
 		public boolean blacklisted() {
 			return blacklistedUntil.filter(v -> v.isAfter(Instant.now())).isPresent();
+		}
+
+		public boolean blacklistExpired() {
+			return blacklistedUntil.isPresent() && !blacklisted();
 		}
 
 		@JsonProperty("lastSuccessfulConnection")

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannel.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannel.java
@@ -80,7 +80,7 @@ import com.radixdlt.network.p2p.transport.handshake.AuthHandshakeResult.AuthHand
 import com.radixdlt.network.p2p.transport.handshake.AuthHandshaker;
 import com.radixdlt.network.p2p.PeerEvent.PeerConnected;
 import com.radixdlt.network.p2p.PeerEvent.PeerDisconnected;
-import com.radixdlt.network.p2p.PeerEvent.PeerConnectionFailed;
+import com.radixdlt.network.p2p.PeerEvent.PeerHandshakeFailed;
 import com.radixdlt.network.p2p.P2PConfig;
 import com.radixdlt.networks.Addressing;
 import com.radixdlt.serialization.Serialization;
@@ -199,7 +199,7 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 				this.finalizeHandshake(handshakeResult);
 			} else {
 				log.info("Failed to connect to {} (invalid handshake)", uri.orElseThrow());
-				peerEventDispatcher.dispatch(PeerConnectionFailed.create(uri.orElseThrow()));
+				peerEventDispatcher.dispatch(PeerHandshakeFailed.create(uri.orElseThrow()));
 				this.disconnect();
 			}
 		} else {

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannel.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannel.java
@@ -200,6 +200,7 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 			} else {
 				log.info("Failed to connect to {} (invalid handshake)", uri.orElseThrow());
 				peerEventDispatcher.dispatch(PeerConnectionFailed.create(uri.orElseThrow()));
+				this.disconnect();
 			}
 		} else {
 			log.trace("Handling auth initiate message from {} [{}]", remoteNodeId, this.nettyChannel.remoteAddress());

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannel.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannel.java
@@ -80,6 +80,7 @@ import com.radixdlt.network.p2p.transport.handshake.AuthHandshakeResult.AuthHand
 import com.radixdlt.network.p2p.transport.handshake.AuthHandshaker;
 import com.radixdlt.network.p2p.PeerEvent.PeerConnected;
 import com.radixdlt.network.p2p.PeerEvent.PeerDisconnected;
+import com.radixdlt.network.p2p.PeerEvent.PeerConnectionFailed;
 import com.radixdlt.network.p2p.P2PConfig;
 import com.radixdlt.networks.Addressing;
 import com.radixdlt.serialization.Serialization;
@@ -95,7 +96,6 @@ import io.reactivex.rxjava3.processors.PublishProcessor;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.bouncycastle.crypto.InvalidCipherTextException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -115,6 +115,9 @@ import static com.radixdlt.network.messaging.MessagingErrors.IO_ERROR;
  */
 public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 	private static final Logger log = LogManager.getLogger();
+
+	private static final byte AUTH_RESPONSE_OK_STATUS = 0x01;
+	private static final byte AUTH_RESPONSE_ERROR_STATUS = 0x02;
 
 	enum ChannelState {
 		INACTIVE, AUTH_HANDSHAKE, ACTIVE
@@ -175,7 +178,7 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 				BackpressureOverflowStrategy.DROP_LATEST);
 	}
 
-	private void initHandshake(NodeId remoteNodeId) throws PublicKeyException {
+	private void initHandshake(NodeId remoteNodeId) {
 		final var initiatePacket = authHandshaker.initiate(remoteNodeId.getPublicKey());
 		log.trace("Sending auth initiate message to {} [{}]", remoteNodeId, this.nettyChannel.remoteAddress());
 		this.write(initiatePacket);
@@ -185,16 +188,29 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 		return inboundMessages;
 	}
 
-	private void handleHandshakeData(byte[] data) throws IOException, InvalidCipherTextException, PublicKeyException {
+	private void handleHandshakeData(byte[] data) throws IOException {
 		if (this.isInitiator) {
 			log.trace("Handling auth response message from {} [{}]", remoteNodeId, this.nettyChannel.remoteAddress());
-			final var handshakeResult = this.authHandshaker.handleResponseMessage(data);
-			this.finalizeHandshake(handshakeResult);
+			final var status = data[0];
+			if (status == AUTH_RESPONSE_OK_STATUS) {
+				final var responsePacket = new byte[data.length - 1];
+				System.arraycopy(data, 1, responsePacket, 0, data.length - 1);
+				final var handshakeResult = this.authHandshaker.handleResponseMessage(responsePacket);
+				this.finalizeHandshake(handshakeResult);
+			} else {
+				log.info("Failed to connect to {} (invalid handshake)", uri.orElseThrow());
+				peerEventDispatcher.dispatch(PeerConnectionFailed.create(uri.orElseThrow()));
+			}
 		} else {
 			log.trace("Handling auth initiate message from {} [{}]", remoteNodeId, this.nettyChannel.remoteAddress());
 			final var result = this.authHandshaker.handleInitialMessage(data);
-			if (result.getFirst() != null) {
-				this.write(result.getFirst());
+			if (result.getSecond() instanceof AuthHandshakeSuccess) {
+				final var packet = new byte[result.getFirst().length + 1];
+				packet[0] = AUTH_RESPONSE_OK_STATUS;
+				System.arraycopy(result.getFirst(), 0, packet, 1, result.getFirst().length);
+				this.write(packet);
+			} else {
+				this.write(new byte[] {AUTH_RESPONSE_ERROR_STATUS});
 			}
 			this.finalizeHandshake(result.getSecond());
 		}
@@ -203,11 +219,11 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 	private void finalizeHandshake(AuthHandshakeResult handshakeResult) {
 		if (handshakeResult instanceof AuthHandshakeSuccess) {
 			final var successResult = (AuthHandshakeSuccess) handshakeResult;
-			log.trace("Finalizing successful auth handshake with {} [{}]",
-				remoteNodeId, this.nettyChannel.remoteAddress());
 			this.remoteNodeId = successResult.getRemoteNodeId();
 			this.frameCodec = new FrameCodec(successResult.getSecrets());
 			this.state = ChannelState.ACTIVE;
+			log.trace("Finalizing successful auth handshake with {} [{}]",
+				remoteNodeId, this.nettyChannel.remoteAddress());
 			peerEventDispatcher.dispatch(PeerConnected.create(this));
 		} else {
 			final var errorResult = (AuthHandshakeError) handshakeResult;

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerServerBootstrap.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerServerBootstrap.java
@@ -129,8 +129,6 @@ public final class PeerServerBootstrap {
 			.channel(NioServerSocketChannel.class)
 			.option(ChannelOption.SO_BACKLOG, BACKLOG_SIZE)
 			.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, config.peerConnectionTimeout())
-			.option(ChannelOption.TCP_NODELAY, true)
-			.option(ChannelOption.SO_KEEPALIVE, true)
 			.childHandler(new PeerChannelInitializer(
 				config,
 				addressing,

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/handshake/AuthHandshaker.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/handshake/AuthHandshaker.java
@@ -164,7 +164,7 @@ public final class AuthHandshaker {
 		);
 	}
 
-	public Pair<byte[], AuthHandshakeResult> handleInitialMessage(byte[] data) throws IOException {
+	public Pair<byte[], AuthHandshakeResult> handleInitialMessage(byte[] data) {
 		try {
 			final var sizeBytes = Arrays.copyOfRange(data, 0, 2);
 			final var encryptedPayload = Arrays.copyOfRange(data, 2, data.length);
@@ -205,7 +205,7 @@ public final class AuthHandshaker {
 
 			final var handshakeResult = finalizeHandshake(remoteEphemeralKey, message.getNonce());
 			return Pair.of(packet, handshakeResult);
-		} catch (PublicKeyException | InvalidCipherTextException ex) {
+		} catch (PublicKeyException | InvalidCipherTextException | IOException ex) {
 			return Pair.of(null, AuthHandshakeResult.error("Handshake decryption failed", Optional.empty()));
 		}
 	}

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/AddressBookEntrySerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/AddressBookEntrySerializeTest.java
@@ -68,6 +68,7 @@ import com.google.common.collect.ImmutableSet;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.network.p2p.NodeId;
 import com.radixdlt.network.p2p.RadixNodeUri;
+import com.radixdlt.network.p2p.addressbook.AddressBookEntry.PeerAddressEntry;
 import org.radix.serialization.SerializeMessageObject;
 
 import java.time.Instant;
@@ -91,7 +92,8 @@ public class AddressBookEntrySerializeTest extends SerializeMessageObject<Addres
 			"127.0.0.1",
 			30000
 		);
-		final var addressEntry = new AddressBookEntry.PeerAddressEntry(uri, Optional.of(Instant.ofEpochMilli(Math.abs(rnd.nextLong()))));
+		final var blacklisted = rnd.nextBoolean();
+		final var addressEntry = new PeerAddressEntry(uri, Optional.of(Instant.ofEpochMilli(Math.abs(rnd.nextLong()))), blacklisted);
 		return new AddressBookEntry(NodeId.fromPublicKey(keyPair.getPublicKey()), bannedUntil, ImmutableSet.of(addressEntry));
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/AddressBookEntrySerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/AddressBookEntrySerializeTest.java
@@ -92,8 +92,10 @@ public class AddressBookEntrySerializeTest extends SerializeMessageObject<Addres
 			"127.0.0.1",
 			30000
 		);
-		final var blacklisted = rnd.nextBoolean();
-		final var addressEntry = new PeerAddressEntry(uri, Optional.of(Instant.ofEpochMilli(Math.abs(rnd.nextLong()))), blacklisted);
+		final var blacklistedUntil = rnd.nextBoolean()
+			? Optional.of(Instant.ofEpochMilli(Math.abs(rnd.nextLong())))
+			: Optional.<Instant>empty();
+		final var addressEntry = new PeerAddressEntry(uri, Optional.of(Instant.ofEpochMilli(Math.abs(rnd.nextLong()))), blacklistedUntil);
 		return new AddressBookEntry(NodeId.fromPublicKey(keyPair.getPublicKey()), bannedUntil, ImmutableSet.of(addressEntry));
 	}
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/test/MockP2PNetwork.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/test/MockP2PNetwork.java
@@ -100,7 +100,9 @@ final class MockP2PNetwork {
 
 	void createChannel(int clientPeerIndex, RadixNodeUri serverPeerUri) {
 		final var clientPeer = nodes.get(clientPeerIndex);
-		final var serverPeer = nodes.stream().filter(p -> p.uri.equals(serverPeerUri)).findAny().get();
+		final var serverPeer = nodes.stream()
+			.filter(p -> p.uri.getHost().equals(serverPeerUri.getHost()) && p.uri.getPort() == serverPeerUri.getPort())
+			.findAny().get();
 
 		final var clientSocketChannel = mock(SocketChannel.class);
 		final var serverSocketChannel = mock(SocketChannel.class);

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/transport/handshake/AuthHandshakerTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/transport/handshake/AuthHandshakerTest.java
@@ -100,7 +100,7 @@ public final class AuthHandshakerTest {
 	}
 
 	@Test
-	public void test_auth_handshake_fail_on_network_id_mismatch() throws Exception {
+	public void test_auth_handshake_fail_on_network_id_mismatch() {
 		final var nodeKey1 = ECKeyPair.generateNew();
 		final var nodeKey2 = ECKeyPair.generateNew();
 		final var handshaker1 = new AuthHandshaker(serialization, secureRandom, ECKeyOps.fromKeyPair(nodeKey1), (byte) 0x01);

--- a/radixdlt-java/radixdlt-cli/src/main/java/com/radixdlt/cloud/AWSSecrets.java
+++ b/radixdlt-java/radixdlt-cli/src/main/java/com/radixdlt/cloud/AWSSecrets.java
@@ -1,8 +1,6 @@
 package com.radixdlt.cloud;
 
-import com.radixdlt.identifiers.AccountAddressing;
 import com.radixdlt.identifiers.NodeAddressing;
-import com.radixdlt.identifiers.REAddr;
 import com.radixdlt.identifiers.ValidatorAddressing;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;


### PR DESCRIPTION
This PR adds blacklisting of a single node URI, in contrast to banning a peer (all known URIs for a node id).
The new mechanism is used to blacklist an URI when a p2p handshake fails.
Handshake response packet now includes an extra prefix byte indicating the status (0x01 = success, 0x02 = error) which is used to signal a failure while handling auth initiate message back to the initiator.