### PR TITLE
Fix p2p auth handshake backwards compatibility

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerEvent.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerEvent.java
@@ -66,8 +66,6 @@ package com.radixdlt.network.p2p;
 
 import com.radixdlt.network.p2p.transport.PeerChannel;
 
-import java.util.Objects;
-
 public interface PeerEvent {
 
 	final class PeerConnected implements PeerEvent {
@@ -84,23 +82,6 @@ public interface PeerEvent {
 
 		public PeerChannel getChannel() {
 			return this.channel;
-		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) {
-				return true;
-			}
-			if (o == null || getClass() != o.getClass()) {
-				return false;
-			}
-			final var that = (PeerConnected) o;
-			return Objects.equals(channel, that.channel);
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(channel);
 		}
 	}
 
@@ -119,23 +100,6 @@ public interface PeerEvent {
 		public PeerChannel getChannel() {
 			return this.channel;
 		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) {
-				return true;
-			}
-			if (o == null || getClass() != o.getClass()) {
-				return false;
-			}
-			final var that = (PeerDisconnected) o;
-			return Objects.equals(channel, that.channel);
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(channel);
-		}
 	}
 
 	final class PeerLostLiveness implements PeerEvent {
@@ -152,23 +116,6 @@ public interface PeerEvent {
 
 		public NodeId getNodeId() {
 			return this.nodeId;
-		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) {
-				return true;
-			}
-			if (o == null || getClass() != o.getClass()) {
-				return false;
-			}
-			final var that = (PeerLostLiveness) o;
-			return Objects.equals(nodeId, that.nodeId);
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(nodeId);
 		}
 	}
 
@@ -187,56 +134,22 @@ public interface PeerEvent {
 		public NodeId getNodeId() {
 			return this.nodeId;
 		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) {
-				return true;
-			}
-			if (o == null || getClass() != o.getClass()) {
-				return false;
-			}
-			final var that = (PeerBanned) o;
-			return Objects.equals(nodeId, that.nodeId);
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(nodeId);
-		}
 	}
 
 	final class PeerHandshakeFailed implements PeerEvent {
 
-		private final RadixNodeUri uri;
+		private final PeerChannel channel;
 
-		public static PeerHandshakeFailed create(RadixNodeUri uri) {
-			return new PeerHandshakeFailed(uri);
+		public static PeerHandshakeFailed create(PeerChannel channel) {
+			return new PeerHandshakeFailed(channel);
 		}
 
-		private PeerHandshakeFailed(RadixNodeUri uri) {
-			this.uri = uri;
+		private PeerHandshakeFailed(PeerChannel channel) {
+			this.channel = channel;
 		}
 
-		public RadixNodeUri getUri() {
-			return this.uri;
-		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) {
-				return true;
-			}
-			if (o == null || getClass() != o.getClass()) {
-				return false;
-			}
-			final var that = (PeerHandshakeFailed) o;
-			return Objects.equals(uri, that.uri);
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(uri);
+		public PeerChannel getChannel() {
+			return this.channel;
 		}
 	}
 }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerManager.java
@@ -328,6 +328,6 @@ public final class PeerManager {
 	}
 
 	private void handlePeerHandshakeFailed(PeerHandshakeFailed peerHandshakeFailed) {
-		this.addressBook.get().blacklist(peerHandshakeFailed.getUri());
+		peerHandshakeFailed.getChannel().getUri().ifPresent(this.addressBook.get()::blacklist);
 	}
 }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PendingOutboundChannelsManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PendingOutboundChannelsManager.java
@@ -133,10 +133,12 @@ public final class PendingOutboundChannelsManager {
 
 	private void handlePeerHandshakeFailed(PeerEvent.PeerHandshakeFailed peerHandshakeFailed) {
 		synchronized (lock) {
-			final var maybeFuture = this.pendingChannels.remove(peerHandshakeFailed.getUri().getNodeId());
-			if (maybeFuture != null) {
-				maybeFuture.completeExceptionally(new IOException("Peer connection failed"));
-			}
+			peerHandshakeFailed.getChannel().getUri().ifPresent(uri -> {
+				final var maybeFuture = this.pendingChannels.remove(uri.getNodeId());
+				if (maybeFuture != null) {
+					maybeFuture.completeExceptionally(new IOException("Peer connection failed"));
+				}
+			});
 		}
 	}
 

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannel.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannel.java
@@ -71,7 +71,6 @@ import com.radixdlt.crypto.exception.PublicKeyException;
 import com.radixdlt.environment.EventDispatcher;
 import com.radixdlt.network.messaging.InboundMessage;
 import com.radixdlt.network.p2p.NodeId;
-import com.radixdlt.network.p2p.PeerControl;
 import com.radixdlt.network.p2p.RadixNodeUri;
 import com.radixdlt.network.p2p.PeerEvent;
 import com.radixdlt.network.p2p.transport.handshake.AuthHandshakeResult;

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannel.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannel.java
@@ -116,9 +116,6 @@ import static com.radixdlt.network.messaging.MessagingErrors.IO_ERROR;
 public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 	private static final Logger log = LogManager.getLogger();
 
-	private static final byte AUTH_RESPONSE_OK_STATUS = 0x01;
-	private static final byte AUTH_RESPONSE_ERROR_STATUS = 0x02;
-
 	enum ChannelState {
 		INACTIVE, AUTH_HANDSHAKE, ACTIVE
 	}
@@ -131,7 +128,6 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 	private final SystemCounters counters;
 	private final Addressing addressing;
 	private final EventDispatcher<PeerEvent> peerEventDispatcher;
-	private final PeerControl peerControl;
 	private final Optional<RadixNodeUri> uri;
 	private final AuthHandshaker authHandshaker;
 	private final boolean isInitiator;
@@ -152,14 +148,12 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 		SecureRandom secureRandom,
 		ECKeyOps ecKeyOps,
 		EventDispatcher<PeerEvent> peerEventDispatcher,
-		PeerControl peerControl,
 		Optional<RadixNodeUri> uri,
 		SocketChannel nettyChannel
 	) {
 		this.counters = Objects.requireNonNull(counters);
 		this.addressing = Objects.requireNonNull(addressing);
 		this.peerEventDispatcher = Objects.requireNonNull(peerEventDispatcher);
-		this.peerControl = Objects.requireNonNull(peerControl);
 		this.uri = Objects.requireNonNull(uri);
 		uri.ifPresent(u -> this.remoteNodeId = u.getNodeId());
 		this.authHandshaker = new AuthHandshaker(serialization, secureRandom, ecKeyOps, networkId);
@@ -173,14 +167,14 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 				() -> {
 					this.counters.increment(SystemCounters.CounterType.NETWORKING_TCP_DROPPED_MESSAGES);
 					final var logLevel = droppedMessagesRateLimiter.tryAcquire() ? Level.WARN : Level.TRACE;
-					log.log(logLevel, "TCP msg buffer overflow, dropping msg");
+					log.log(logLevel, "TCP msg buffer overflow, dropping msg on {}", this.toString());
 				},
 				BackpressureOverflowStrategy.DROP_LATEST);
 	}
 
 	private void initHandshake(NodeId remoteNodeId) {
 		final var initiatePacket = authHandshaker.initiate(remoteNodeId.getPublicKey());
-		log.trace("Sending auth initiate message to {} [{}]", remoteNodeId, this.nettyChannel.remoteAddress());
+		log.trace("Sending auth initiate to {}", this.toString());
 		this.write(initiatePacket);
 	}
 
@@ -190,28 +184,14 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 
 	private void handleHandshakeData(byte[] data) throws IOException {
 		if (this.isInitiator) {
-			log.trace("Handling auth response message from {} [{}]", remoteNodeId, this.nettyChannel.remoteAddress());
-			final var status = data[0];
-			if (status == AUTH_RESPONSE_OK_STATUS) {
-				final var responsePacket = new byte[data.length - 1];
-				System.arraycopy(data, 1, responsePacket, 0, data.length - 1);
-				final var handshakeResult = this.authHandshaker.handleResponseMessage(responsePacket);
-				this.finalizeHandshake(handshakeResult);
-			} else {
-				log.info("Failed to connect to {} (invalid handshake)", uri.orElseThrow());
-				peerEventDispatcher.dispatch(PeerHandshakeFailed.create(uri.orElseThrow()));
-				this.disconnect();
-			}
+			log.trace("Auth response from {}", this.toString());
+			final var handshakeResult = this.authHandshaker.handleResponseMessage(data);
+			this.finalizeHandshake(handshakeResult);
 		} else {
-			log.trace("Handling auth initiate message from {} [{}]", remoteNodeId, this.nettyChannel.remoteAddress());
+			log.trace("Auth initiate from {}", this.toString());
 			final var result = this.authHandshaker.handleInitialMessage(data);
-			if (result.getSecond() instanceof AuthHandshakeSuccess) {
-				final var packet = new byte[result.getFirst().length + 1];
-				packet[0] = AUTH_RESPONSE_OK_STATUS;
-				System.arraycopy(result.getFirst(), 0, packet, 1, result.getFirst().length);
-				this.write(packet);
-			} else {
-				this.write(new byte[] {AUTH_RESPONSE_ERROR_STATUS});
+			if (result.getFirst() != null) {
+				this.write(result.getFirst());
 			}
 			this.finalizeHandshake(result.getSecond());
 		}
@@ -223,15 +203,11 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 			this.remoteNodeId = successResult.getRemoteNodeId();
 			this.frameCodec = new FrameCodec(successResult.getSecrets());
 			this.state = ChannelState.ACTIVE;
-			log.trace("Finalizing successful auth handshake with {} [{}]",
-				remoteNodeId, this.nettyChannel.remoteAddress());
+			log.trace("Successful auth handshake: {}", this.toString());
 			peerEventDispatcher.dispatch(PeerConnected.create(this));
 		} else {
 			final var errorResult = (AuthHandshakeError) handshakeResult;
-			log.warn("Auth handshake failed with {} [{}] because of: {}. Disconnecting and banning peer.",
-				remoteNodeId, this.nettyChannel.remoteAddress(), errorResult.getMsg());
-			errorResult.getMaybeNodeId().ifPresent(remoteNodeId ->
-				this.peerControl.banPeer(remoteNodeId, Duration.ofHours(1), "Auth handshake failed"));
+			log.warn("Auth handshake failed on {}: {}", this.toString(), errorResult.getMsg());
 			this.disconnect();
 		}
 	}
@@ -241,7 +217,7 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 			final var maybeFrame = this.frameCodec.tryReadSingleFrame(buf);
 			maybeFrame.ifPresentOrElse(
 				frame -> inboundMessageSink.onNext(InboundMessage.of(remoteNodeId, frame)),
-				() -> log.error("Failed to read a complete frame from {}", nettyChannel.remoteAddress())
+				() -> log.error("Failed to read a complete frame: {}", this.toString())
 			);
 		}
 	}
@@ -250,7 +226,7 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 	public void channelActive(ChannelHandlerContext ctx) throws PublicKeyException {
 		this.state = ChannelState.AUTH_HANDSHAKE;
 
-		log.trace("Peer channel active to {}, isInitiator ?= {}", this.nettyChannel.remoteAddress(), isInitiator);
+		log.trace("Active: {}", this.toString());
 
 		if (this.isInitiator) {
 			this.initHandshake(this.remoteNodeId);
@@ -273,18 +249,16 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 
 	@Override
 	public void channelInactive(ChannelHandlerContext ctx) {
-		log.info("Channel closed {} at state {} [initiator ?= {}, remoteNodeId = {}, nodeAddress = {}, uri = {}]",
-			ctx.channel().remoteAddress(),
-			this.state,
-			this.isInitiator,
-			this.remoteNodeId != null ? this.remoteNodeId : "unknown",
-		 	this.remoteNodeId != null ? addressing.forNodes().of(this.remoteNodeId.getPublicKey()) : "unknown",
-			this.uri
-		);
+		log.info("Closed: {}", this.toString());
 
 		final var prevState = this.state;
 		this.state = ChannelState.INACTIVE;
 		this.inboundMessageSink.onComplete();
+
+		if (prevState == ChannelState.AUTH_HANDSHAKE) {
+			uri.ifPresent(u -> peerEventDispatcher.dispatch(PeerHandshakeFailed.create(this)));
+		}
+
 		if (prevState == ChannelState.ACTIVE) {
 			// only send out event if peer was previously active
 			this.peerEventDispatcher.dispatch(PeerDisconnected.create(this));
@@ -293,16 +267,7 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 
 	@Override
 	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-		log.warn("Exception on channel {} at state {} [initiator ?= {}, remoteNodeId = {}, nodeAddress = {}, uri = {}]: {}",
-			ctx.channel().remoteAddress(),
-			this.state,
-			this.isInitiator,
-			this.remoteNodeId != null ? this.remoteNodeId : "unknown",
-			this.remoteNodeId != null ? addressing.forNodes().of(this.remoteNodeId.getPublicKey()) : "unknown",
-			this.uri,
-			cause.getMessage()
-		);
-
+		log.warn("Exception on {}: {}", this.toString(), cause.getMessage());
 		ctx.close();
 	}
 
@@ -356,5 +321,23 @@ public final class PeerChannel extends SimpleChannelInboundHandler<byte[]> {
 
 	public InetSocketAddress getRemoteSocketAddress() {
 		return (InetSocketAddress) this.nettyChannel.remoteAddress();
+	}
+
+	@Override
+	public String toString() {
+		final var hostString = nettyChannel.remoteAddress() instanceof InetSocketAddress
+			? ((InetSocketAddress) nettyChannel.remoteAddress()).getHostString()
+			: "?";
+		final var port = nettyChannel.remoteAddress() instanceof InetSocketAddress
+			? ((InetSocketAddress) nettyChannel.remoteAddress()).getPort()
+			: 0;
+		return String.format(
+			"{%s %s@%s:%s | %s}",
+			isInitiator ? "<-" : "->",
+			remoteNodeId != null ? addressing.forNodes().of(this.remoteNodeId.getPublicKey()) : "?",
+			hostString,
+			port,
+			state
+		);
 	}
 }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannelInitializer.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannelInitializer.java
@@ -67,7 +67,6 @@ package com.radixdlt.network.p2p.transport;
 import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.crypto.ECKeyOps;
 import com.radixdlt.environment.EventDispatcher;
-import com.radixdlt.network.p2p.PeerControl;
 import com.radixdlt.network.p2p.RadixNodeUri;
 import com.radixdlt.network.p2p.PeerEvent;
 import com.radixdlt.network.p2p.P2PConfig;
@@ -103,7 +102,6 @@ public final class PeerChannelInitializer extends ChannelInitializer<SocketChann
 	private final SecureRandom secureRandom;
 	private final ECKeyOps ecKeyOps;
 	private final EventDispatcher<PeerEvent> peerEventDispatcher;
-	private final PeerControl peerControl;
 	private final Optional<RadixNodeUri> uri;
 
 	public PeerChannelInitializer(
@@ -115,7 +113,6 @@ public final class PeerChannelInitializer extends ChannelInitializer<SocketChann
 		SecureRandom secureRandom,
 		ECKeyOps ecKeyOps,
 		EventDispatcher<PeerEvent> peerEventDispatcher,
-		PeerControl peerControl,
 		Optional<RadixNodeUri> uri
 	) {
 		this.config = Objects.requireNonNull(config);
@@ -126,7 +123,6 @@ public final class PeerChannelInitializer extends ChannelInitializer<SocketChann
 		this.secureRandom = Objects.requireNonNull(secureRandom);
 		this.ecKeyOps = Objects.requireNonNull(ecKeyOps);
 		this.peerEventDispatcher = Objects.requireNonNull(peerEventDispatcher);
-		this.peerControl = Objects.requireNonNull(peerControl);
 		this.uri = Objects.requireNonNull(uri);
 	}
 
@@ -141,7 +137,6 @@ public final class PeerChannelInitializer extends ChannelInitializer<SocketChann
 			secureRandom,
 			ecKeyOps,
 			peerEventDispatcher,
-			peerControl,
 			uri,
 			socketChannel
 		);

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerOutboundBootstrapImpl.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerOutboundBootstrapImpl.java
@@ -65,12 +65,10 @@
 package com.radixdlt.network.p2p.transport;
 
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.crypto.ECKeyOps;
 import com.radixdlt.environment.EventDispatcher;
 import com.radixdlt.network.p2p.P2PConfig;
-import com.radixdlt.network.p2p.PeerControl;
 import com.radixdlt.network.p2p.PeerEvent;
 import com.radixdlt.network.p2p.RadixNodeUri;
 import com.radixdlt.networks.Addressing;
@@ -94,7 +92,6 @@ public final class PeerOutboundBootstrapImpl implements PeerOutboundBootstrap {
 	private final SecureRandom secureRandom;
 	private final ECKeyOps ecKeyOps;
 	private final EventDispatcher<PeerEvent> peerEventDispatcher;
-	private Provider<PeerControl> peerControl;
 
 	private final NioEventLoopGroup clientWorkerGroup;
 
@@ -107,8 +104,7 @@ public final class PeerOutboundBootstrapImpl implements PeerOutboundBootstrap {
 		Serialization serialization,
 		SecureRandom secureRandom,
 		ECKeyOps ecKeyOps,
-		EventDispatcher<PeerEvent> peerEventDispatcher,
-		Provider<PeerControl> peerControl
+		EventDispatcher<PeerEvent> peerEventDispatcher
 	) {
 		this.config = Objects.requireNonNull(config);
 		this.addressing = Objects.requireNonNull(addressing);
@@ -118,7 +114,6 @@ public final class PeerOutboundBootstrapImpl implements PeerOutboundBootstrap {
 		this.secureRandom = Objects.requireNonNull(secureRandom);
 		this.ecKeyOps = Objects.requireNonNull(ecKeyOps);
 		this.peerEventDispatcher = Objects.requireNonNull(peerEventDispatcher);
-		this.peerControl = Objects.requireNonNull(peerControl);
 
 		this.clientWorkerGroup = new NioEventLoopGroup();
 	}
@@ -139,7 +134,6 @@ public final class PeerOutboundBootstrapImpl implements PeerOutboundBootstrap {
 				secureRandom,
 				ecKeyOps,
 				peerEventDispatcher,
-				peerControl.get(),
 				Optional.of(uri)
 			))
 			.connect(uri.getHost(), uri.getPort());

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerServerBootstrap.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerServerBootstrap.java
@@ -65,11 +65,9 @@
 package com.radixdlt.network.p2p.transport;
 
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.crypto.ECKeyOps;
 import com.radixdlt.environment.EventDispatcher;
-import com.radixdlt.network.p2p.PeerControl;
 import com.radixdlt.network.p2p.PeerEvent;
 import com.radixdlt.network.p2p.P2PConfig;
 import com.radixdlt.networks.Addressing;
@@ -95,7 +93,6 @@ public final class PeerServerBootstrap {
 	private final SecureRandom secureRandom;
 	private final ECKeyOps ecKeyOps;
 	private final EventDispatcher<PeerEvent> peerEventDispatcher;
-	private final Provider<PeerControl> peerControl;
 
 	@Inject
 	public PeerServerBootstrap(
@@ -106,8 +103,7 @@ public final class PeerServerBootstrap {
 		Serialization serialization,
 		SecureRandom secureRandom,
 		ECKeyOps ecKeyOps,
-		EventDispatcher<PeerEvent> peerEventDispatcher,
-		Provider<PeerControl> peerControl
+		EventDispatcher<PeerEvent> peerEventDispatcher
 	) {
 		this.config = Objects.requireNonNull(config);
 		this.addressing = Objects.requireNonNull(addressing);
@@ -117,7 +113,6 @@ public final class PeerServerBootstrap {
 		this.secureRandom = Objects.requireNonNull(secureRandom);
 		this.ecKeyOps = Objects.requireNonNull(ecKeyOps);
 		this.peerEventDispatcher = Objects.requireNonNull(peerEventDispatcher);
-		this.peerControl = Objects.requireNonNull(peerControl);
 	}
 
 	public void start() throws InterruptedException {
@@ -138,7 +133,6 @@ public final class PeerServerBootstrap {
 				secureRandom,
 				ecKeyOps,
 				peerEventDispatcher,
-				peerControl.get(),
 				Optional.empty()
 			));
 

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/handshake/AuthHandshaker.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/handshake/AuthHandshaker.java
@@ -206,7 +206,10 @@ public final class AuthHandshaker {
 			final var handshakeResult = finalizeHandshake(remoteEphemeralKey, message.getNonce());
 			return Pair.of(packet, handshakeResult);
 		} catch (PublicKeyException | InvalidCipherTextException | IOException ex) {
-			return Pair.of(null, AuthHandshakeResult.error("Handshake decryption failed", Optional.empty()));
+			return Pair.of(null, AuthHandshakeResult.error(
+				String.format("Handshake decryption failed (%s)", ex.getMessage()),
+				Optional.empty())
+			);
 		}
 	}
 
@@ -220,7 +223,10 @@ public final class AuthHandshaker {
 			final var remoteEphemeralKey = ECPublicKey.fromBytes(message.getEphemeralPublicKey().asBytes());
 			return finalizeHandshake(remoteEphemeralKey, message.getNonce());
 		} catch (PublicKeyException | InvalidCipherTextException ex) {
-			return AuthHandshakeResult.error("Handshake decryption failed", Optional.empty());
+			return AuthHandshakeResult.error(
+				String.format("Handshake decryption failed (%s)", ex.getMessage()),
+				Optional.empty()
+			);
 		}
 	}
 

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/liveness/PeerLivenessMonitorTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/liveness/PeerLivenessMonitorTest.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 import static com.radixdlt.utils.TypedMocks.rmock;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -64,7 +65,10 @@ public class PeerLivenessMonitorTest {
 
 		this.sut.pingTimeoutEventProcessor().process(PeerPingTimeout.create(NodeId.fromPublicKey(peer1.getKey())));
 
-		verify(peerEventDispatcher, times(1)).dispatch(PeerLostLiveness.create(NodeId.fromPublicKey(peer1.getKey())));
+		verify(peerEventDispatcher, times(1)).dispatch(argThat(arg ->
+			arg instanceof PeerLostLiveness
+				&& ((PeerLostLiveness) arg).getNodeId().equals(NodeId.fromPublicKey(peer1.getKey()))
+		));
 	}
 
 	@Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/test/MockP2PNetwork.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/test/MockP2PNetwork.java
@@ -72,7 +72,6 @@ import com.google.inject.Key;
 import com.radixdlt.counters.SystemCounters;
 import com.radixdlt.environment.EventDispatcher;
 import com.radixdlt.network.p2p.P2PConfig;
-import com.radixdlt.network.p2p.PeerControl;
 import com.radixdlt.network.p2p.PeerEvent;
 import com.radixdlt.network.p2p.RadixNodeUri;
 import com.radixdlt.network.p2p.transport.PeerChannel;
@@ -116,7 +115,6 @@ final class MockP2PNetwork {
 			new SecureRandom(),
 			ECKeyOps.fromKeyPair(clientPeer.keyPair),
 			clientPeer.injector.getInstance(new Key<EventDispatcher<PeerEvent>>() { }),
-			clientPeer.injector.getInstance(PeerControl.class),
 			Optional.of(serverPeerUri),
 			clientSocketChannel
 		);
@@ -130,7 +128,6 @@ final class MockP2PNetwork {
 			new SecureRandom(),
 			ECKeyOps.fromKeyPair(serverPeer.keyPair),
 			serverPeer.injector.getInstance(new Key<EventDispatcher<PeerEvent>>() { }),
-			clientPeer.injector.getInstance(PeerControl.class),
 			Optional.empty(),
 			serverSocketChannel
 		);

--- a/radixdlt-java-common/src/main/java/com/radixdlt/crypto/IESEngine.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/crypto/IESEngine.java
@@ -378,7 +378,7 @@ public class IESEngine {
         mac.doFinal(t2, 0);
 
         if (!Arrays.constantTimeAreEqual(t1, t2)) {
-            throw new InvalidCipherTextException("Invalid MAC.");
+            throw new InvalidCipherTextException("Invalid MAC");
         }
 
         // Output the message.


### PR DESCRIPTION
This brings back p2p backwards compatibility.
Instead of signaling auth handshake error back to the "client" explicitly with a status byte, client side now assumes that if connection is closed at the auth handshake state then it's the handshake that failed. It is possible that the connection is closed for other reason, unrelated to handshake, but it's rather unlikely and even if so, it won't do any damage (other than temporarily blacklisting an URI).