### PR TITLE
Filter spendables with zero balance

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/store/berkeley/BerkeleyClientApiStore.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/store/berkeley/BerkeleyClientApiStore.java
@@ -326,6 +326,7 @@ public final class BerkeleyClientApiStore implements ClientApiStore {
 					.toOptional()
 					.filter(entry -> entry.getType().equals(type))
 					.filter(entry -> entry.getOwner().equals(addr))
+					.filter(entry -> type != BalanceType.SPENDABLE || !entry.getAmount().isZero())
 					.map(entry -> entry.rri().equals("stake-ownership") ? computeStakeEntry(entry) : entry)
 					.ifPresent(list::add);
 


### PR DESCRIPTION
Changes summary:
- Do not return balance entries if they have zero balance and are not stakes/unstakes
