### PR TITLE
Wrong network ID in java library fix

### DIFF
--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/async/AsyncRadixApi.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/async/AsyncRadixApi.java
@@ -498,6 +498,7 @@ public class AsyncRadixApi extends RadixApiBase implements RadixApi {
 			.orElseGet(BASE_URL_IS_MANDATORY::result)
 			.flatMap(asyncRadixApi -> asyncRadixApi.network().id().join()
 				.onSuccess(networkId -> asyncRadixApi.configureSerialization(networkId.getNetworkId()))
+				.onSuccess(networkId -> asyncRadixApi.setNetworkId(networkId.getNetworkId()))
 				.map(__ -> asyncRadixApi))
 			.fold(Promise::failure, Promise::ok);
 	}

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/async/AsyncRadixApi.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/async/AsyncRadixApi.java
@@ -497,8 +497,7 @@ public class AsyncRadixApi extends RadixApiBase implements RadixApi {
 			.map(baseUrl -> Result.ok(new AsyncRadixApi(baseUrl, primaryPort, secondaryPort, client, authentication)))
 			.orElseGet(BASE_URL_IS_MANDATORY::result)
 			.flatMap(asyncRadixApi -> asyncRadixApi.network().id().join()
-				.onSuccess(networkId -> asyncRadixApi.configureSerialization(networkId.getNetworkId()))
-				.onSuccess(networkId -> asyncRadixApi.setNetworkId(networkId.getNetworkId()))
+				.onSuccess(networkId -> asyncRadixApi.configure(networkId.getNetworkId()))
 				.map(__ -> asyncRadixApi))
 			.fold(Promise::failure, Promise::ok);
 	}

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/rpc/RadixApiBase.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/rpc/RadixApiBase.java
@@ -186,7 +186,7 @@ public abstract class RadixApiBase {
 		return networkId;
 	}
 
-	public void setNetworkId(int networkId) {
+	protected void setNetworkId(int networkId) {
 		this.networkId = networkId;
 	}
 

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/rpc/RadixApiBase.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/rpc/RadixApiBase.java
@@ -231,6 +231,11 @@ public abstract class RadixApiBase {
 			.build());
 	}
 
+	protected void configure(int networkId) {
+		configureSerialization(networkId);
+		setNetworkId(networkId);
+	}
+
 	protected void configureSerialization(int networkId) {
 		var module = new SimpleModule()
 			.addSerializer(ValidatorAddress.class, new ValidatorAddressSerializer(networkId))
@@ -272,4 +277,5 @@ public abstract class RadixApiBase {
 	private static ObjectMapper createDefaultMapper() {
 		return new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
 	}
+
 }

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/rpc/RadixApiBase.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/rpc/RadixApiBase.java
@@ -186,6 +186,10 @@ public abstract class RadixApiBase {
 		return networkId;
 	}
 
+	public void setNetworkId(int networkId) {
+		this.networkId = networkId;
+	}
+
 	protected HttpClient client() {
 		return client;
 	}

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/sync/SyncRadixApi.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/sync/SyncRadixApi.java
@@ -522,8 +522,7 @@ public class SyncRadixApi extends RadixApiBase implements RadixApi {
 			.map(baseUrl -> Result.ok(new SyncRadixApi(baseUrl, primaryPort, secondaryPort, client, authentication)))
 			.orElseGet(BASE_URL_IS_MANDATORY::result)
 			.flatMap(syncRadixApi -> syncRadixApi.network().id()
-				.onSuccess(networkId -> syncRadixApi.configureSerialization(networkId.getNetworkId()))
-				.onSuccess(networkId -> syncRadixApi.setNetworkId(networkId.getNetworkId()))
+				.onSuccess(networkId -> syncRadixApi.configure(networkId.getNetworkId()))
 				.map(__ -> syncRadixApi));
 	}
 

--- a/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/sync/SyncRadixApi.java
+++ b/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/sync/SyncRadixApi.java
@@ -523,6 +523,7 @@ public class SyncRadixApi extends RadixApiBase implements RadixApi {
 			.orElseGet(BASE_URL_IS_MANDATORY::result)
 			.flatMap(syncRadixApi -> syncRadixApi.network().id()
 				.onSuccess(networkId -> syncRadixApi.configureSerialization(networkId.getNetworkId()))
+				.onSuccess(networkId -> syncRadixApi.setNetworkId(networkId.getNetworkId()))
 				.map(__ -> syncRadixApi));
 	}
 

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
@@ -64,7 +64,11 @@
 
 package com.radixdlt.test.chaos;
 
-import com.radixdlt.test.chaos.actions.*;
+import com.radixdlt.test.chaos.actions.Action;
+import com.radixdlt.test.chaos.actions.NetworkAction;
+import com.radixdlt.test.chaos.actions.RestartAction;
+import com.radixdlt.test.chaos.actions.ShutdownAction;
+import com.radixdlt.test.chaos.actions.ValidatorUnregistrationAction;
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
 import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;
 import org.apache.logging.log4j.LogManager;

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
@@ -1,4 +1,4 @@
-/* Copyright 2021 Radix DLT Ltd incorporated in England.
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
  *
  * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:
@@ -64,10 +64,10 @@
 
 package com.radixdlt.test.chaos;
 
-import com.radixdlt.test.chaos.actions.Action;
 import com.radixdlt.test.chaos.actions.NetworkAction;
 import com.radixdlt.test.chaos.actions.RestartAction;
 import com.radixdlt.test.chaos.actions.ShutdownAction;
+import com.radixdlt.test.chaos.actions.Action;
 import com.radixdlt.test.chaos.actions.ValidatorUnregistrationAction;
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
 import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;

--- a/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
+++ b/radixdlt-regression/system-tests/src/test/java/com/radixdlt/test/chaos/ChaosExperiments.java
@@ -64,33 +64,12 @@
 
 package com.radixdlt.test.chaos;
 
-import com.radixdlt.application.tokens.Amount;
-import com.radixdlt.client.lib.api.AccountAddress;
-import com.radixdlt.client.lib.api.TransactionRequest;
-import com.radixdlt.client.lib.api.ValidatorAddress;
-import com.radixdlt.client.lib.api.sync.ImperativeRadixApi;
-import com.radixdlt.client.lib.dto.FinalizedTransaction;
-import com.radixdlt.client.lib.dto.TokenBalances;
-import com.radixdlt.client.lib.dto.TxBlobDTO;
-import com.radixdlt.client.lib.dto.TxDTO;
-import com.radixdlt.crypto.ECKeyPair;
-import com.radixdlt.crypto.ECPublicKey;
-import com.radixdlt.crypto.exception.PrivateKeyException;
-import com.radixdlt.crypto.exception.PublicKeyException;
-import com.radixdlt.identifiers.AccountAddressing;
-import com.radixdlt.identifiers.REAddr;
-import com.radixdlt.networks.Addressing;
-import com.radixdlt.networks.Network;
-import com.radixdlt.serialization.DeserializeException;
 import com.radixdlt.test.chaos.actions.*;
 import com.radixdlt.test.chaos.ansible.AnsibleImageWrapper;
 import com.radixdlt.test.chaos.utils.ChaosExperimentUtils;
-import com.radixdlt.utils.Ints;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 public class ChaosExperiments {
@@ -117,101 +96,6 @@ public class ChaosExperiments {
         });
 
         //ChaosExperimentUtils.livenessCheckIgnoringOffline(ansible.toNetwork());
-    }
-
-
-    //@Test
-    public void stake() throws DeserializeException {
-        ECKeyPair richKeyPair = keyPairOf(1);
-        AccountAddress richAccount = AccountAddress.create(richKeyPair.getPublicKey());
-
-//        REAddr stakerREAddr = Addressing.ofNetwork(Network.LOCALNET).forAccounts()
-//            .parse("ddx1qspj7xtr6av9e2pqcqv4nnenz24g759r7yr3qcxrzftjeneyxkvlktchakswt");
-//        AccountAddress staker = AccountAddress.create(stakerREAddr);
-        ECKeyPair stakerKeyPair = ECKeyPair.generateNew();
-        AccountAddress stakerAddress = AccountAddress.create(stakerKeyPair.getPublicKey());
-        System.out.println(stakerAddress);
-
-        ImperativeRadixApi client = ImperativeRadixApi
-            .connect("http://localhost", 8080, 3333);
-
-        Amount amount = Amount.ofTokens(1000000);
-        FinalizedTransaction finalized = client.transaction().build(TransactionRequest
-            .createBuilder(richAccount)
-            .transfer(richAccount, stakerAddress, amount.toSubunits(), "xrd_dr1qyrs8qwl")
-            .build())
-            .toFinalized(richKeyPair);
-        TxBlobDTO postFinal = client.transaction().finalize(finalized, false);
-        TxDTO response = client.transaction().submit(postFinal);
-        System.out.println(response);
-
-        ECPublicKey validatorKey = Addressing.ofNetwork(Network.LOCALNET).forValidators()
-            .parse("tdx1qspykgwyp94yjza3tjxaxagudxgjjy3ghcje6krkpqn7vrkfhq3rjggzdrax3");
-        ValidatorAddress validatorAddress = ValidatorAddress.of(validatorKey);
-        Amount amount2 = Amount.ofTokens(150);
-        FinalizedTransaction finalized2 = client.transaction().build(TransactionRequest
-            .createBuilder(stakerAddress)
-            .stake(stakerAddress, validatorAddress, amount2.toSubunits())
-            .build())
-            .toFinalized(stakerKeyPair);
-        TxBlobDTO postFinal2 = client.transaction().finalize(finalized2, false);
-        TxDTO response2 = client.transaction().submit(postFinal2);
-        System.out.println(response2);
-
-    }
-
-    @Test
-    public void misc() throws PrivateKeyException, PublicKeyException {
-//        ECKeyPair keyPair = keyPairOf(666);
-//        AccountAddress accountAddress = AccountAddress.create(keyPair.getPublicKey());
-//        System.out.println(accountAddress.toString(99));
-//        ImperativeRadixApi radixApi = ImperativeRadixApi.connect("http://localhost",8080, 3333);
-//        TokenBalances balances = radixApi.account().balances(accountAddress);
-//        logger.info(balances);
-
-        AccountAddress accountAddress = AccountAddress.create(ECKeyPair.generateNew().getPublicKey());
-        ImperativeRadixApi radixApi = ImperativeRadixApi.connect("https://rcnet.radixdlt.com",
-            443, 443);
-        radixApi.account().balances(accountAddress);
-    }
-
-    //@Test
-    public void transfer() throws PrivateKeyException, PublicKeyException, DeserializeException {
-
-        System.out.println(Amount.ofTokens(150).toSubunits().toString());
-
-        ECKeyPair richKeyPair = keyPairOf(1);
-        AccountAddress richAccount = AccountAddress.create(richKeyPair.getPublicKey());
-
-//        REAddr destination = Addressing.ofNetwork(Network.STOKENET).forAccounts()
-//            .parse("tdx1qspvkcqggqjftcfjk0te92gvfp42k7qe9myakkeck2hwqt8cv94z9rsy53zh0");
-        REAddr destination = Addressing.ofNetwork(Network.LOCALNET).forAccounts()
-            .parse("ddx1qsph7awxd3z62tp4at2ewzal4t7lhf3x5mwua27pfc8c4rra3zjhw2crx4k8g");
-        AccountAddress faucetAccount = AccountAddress.create(destination);
-
-        Amount amount = Amount.ofTokens(10000);
-        ImperativeRadixApi client = ImperativeRadixApi
-            .connect("http://localhost", 8080, 3333);
-        FinalizedTransaction finalized = client.transaction().build(TransactionRequest
-            .createBuilder(richAccount)
-            .transfer(richAccount, faucetAccount, amount.toSubunits(), "xrd_dr1qyrs8qwl")
-            .build())
-            .toFinalized(richKeyPair);
-        TxBlobDTO postFinal = client.transaction().finalize(finalized, false);
-        TxDTO response = client.transaction().submit(postFinal);
-
-        System.out.println(response);
-    }
-
-    private static ECKeyPair keyPairOf(int pk) {
-        var privateKey = new byte[ECKeyPair.BYTES];
-        Ints.copyTo(pk, privateKey, ECKeyPair.BYTES - Integer.BYTES);
-
-        try {
-            return ECKeyPair.fromPrivateKey(privateKey);
-        } catch (PrivateKeyException | PublicKeyException e) {
-            throw new IllegalArgumentException("Error while generating public key", e);
-        }
     }
 
 }


### PR DESCRIPTION
## set the correct network id when connecting

The RadixApis store the network id, which is hardcoded to localnet ID. See [RadixApiBase:130](https://github.com/radixdlt/radixdlt/blob/a34f7cbbdfe0642a947308c634a8b9cc74f3c640/radixdlt-java/radixdlt-java/src/main/java/com/radixdlt/client/lib/api/rpc/RadixApiBase.java#L130):
```
private int networkId = LOCALNET.getId();
```

This variable is never updated, so it will use localnet's ID even when connecting to other networks e.g. RCNet. This means that requests like this:
```
AccountAddress accountAddress = AccountAddress.create(ECKeyPair.generateNew().getPublicKey());
ImperativeRadixApi radixApi = ImperativeRadixApi.connect("https://rcnet.radixdlt.com", 443, 443);
radixApi.account().balances(accountAddress);
```
Fail due to:
```
Invalid account address com.radixdlt.serialization.DeserializeException: hrp must be tdx4 but was ddx
com.radixdlt.client.lib.api.sync.RadixApiException: Invalid account address com.radixdlt.serialization.DeserializeException: hrp must be tdx4 but was ddx
	at com.radixdlt.client.lib.api.sync.ImperativeRadixApi.lambda$unwrap$0(ImperativeRadixApi.java:524)
	at com.radixdlt.utils.functional.Result$ResultFail.fold(Result.java:389)
	at com.radixdlt.client.lib.api.sync.ImperativeRadixApi.unwrap(ImperativeRadixApi.java:523)
	at com.radixdlt.client.lib.api.sync.ImperativeRadixApi$1$5.balances(ImperativeRadixApi.java:653)
...
```

With this PR, the above error is fixed. I tested this against RCNet.
