### PR TITLE
Run integration tests in parallel

### DIFF
--- a/radixdlt-core/radixdlt/build.gradle
+++ b/radixdlt-core/radixdlt/build.gradle
@@ -113,6 +113,7 @@ configurations {
 task integrationTest(type: Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
+    maxParallelForks = Runtime.runtime.availableProcessors() / 2 //A greater number was tried, but the tests either failed or there was no gain in performance.
     mustRunAfter(test)
 }
 


### PR DESCRIPTION
Currently, integration tests run sequentially and take a long time to finish. This change uses the Gradle `maxParallelForks` property to run the tests in parallel. It is configured to use the number of available cores divided by 2. A greater number was tried, but the tests either failed or there was no gain in performance. 