### PR TITLE
fix issue concurrency issue

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerManager.java
@@ -308,9 +308,11 @@ public final class PeerManager {
 	}
 
 	public ImmutableSet<PeerChannel> activeChannels() {
-		return this.activeChannels.values().stream()
-			.flatMap(Collection::stream)
-			.collect(ImmutableSet.toImmutableSet());
+		synchronized (lock) {
+			return this.activeChannels.values().stream()
+					.flatMap(Collection::stream)
+					.collect(ImmutableSet.toImmutableSet());
+		}
 	}
 
 	public boolean isPeerConnected(NodeId nodeId) {


### PR DESCRIPTION
Collector created by Guava ImmutableSet.toImmutableSet() is not thread safe and might result in ConcurrentModificationException.

Issue addressed: https://github.com/radixdlt/radixdlt/issues/507