### PR TITLE
Fix json stored

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/archive/tokens/BerkeleyResourceInfoStore.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/archive/tokens/BerkeleyResourceInfoStore.java
@@ -178,7 +178,7 @@ public final class BerkeleyResourceInfoStore implements BerkeleyAdditionalStore 
 				var supply = new BigInteger(json.getString("currentSupply"), 10);
 				var change = e.getValue();
 				var newSupply = supply.add(change);
-				json.put("currentSupply", newSupply);
+				json.put("currentSupply", newSupply.toString());
 				if (change.signum() > 0) {
 					var minted = new BigInteger(json.getString("totalMinted"), 10);
 					var newMinted = minted.add(change);


### PR DESCRIPTION
Fix the fact that `currentSupply` is stored as an `integer` rather than a `string`.