### PR TITLE
Update parsing.md

### DIFF
--- a/docs/transaction-specs/specs/parsing.md
+++ b/docs/transaction-specs/specs/parsing.md
@@ -173,7 +173,7 @@ Substates are serialized and deserialized based on the following protocol:
 
 | **Name**      | **Type**          | **Description**                              |
 |---------------|-------------------|----------------------------------------------|
-| `type`        | `u8`              | Reserved, always `0`                         |
+| `reserved`    | `u8`              | Reserved, always `0`                         |
 | `resource`    | `address`         | The resource address                         |
 | `granularity` | `u256`            | The token granularity, must be `1` as of now |
 | `is_mutable`  | `opt<boolean>`    | (Optional) Whether it's mutable              |
@@ -224,7 +224,7 @@ Substates are serialized and deserialized based on the following protocol:
 |-------------|--------------|--------------------------|
 | `reserved`  | `u8`         | Reserved, always `0`     |
 | `validator` | `public_key` | The validator public key |
-| `owner`     | `u256`       | The owner                |
+| `owner`     | `address`    | The owner                |
 | `amount`    | `u256`       | The stake amount         |
 
 #### `EXITING_STAKE`
@@ -234,7 +234,7 @@ Substates are serialized and deserialized based on the following protocol:
 | `reserved`       | `u8`         | Reserved, always `0`     |
 | `epoch_unlocked` | `u64`        | The unlocking epoch      |
 | `validator`      | `public_key` | The validator public key |
-| `owner`          | `u256`       | The owner                |
+| `owner`          | `address`    | The owner                |
 | `amount`         | `u256`       | The stake amount         |
 
 #### `VALIDATOR_META_DATA`


### PR DESCRIPTION


## change of 'owner' data type at PREPARED_UNSTAKE and EXITING_STAKE substate

## Description

Currently the 'owner' datatype is specified as u256, I think it should be address.

In the substate TOKEN_RESOURCE the reserved u8 is marked with 'type' at the beginning, in all others with 'reserved'.

In the description of the optional fields it looks to me like no data should follow for '0x00', but when I look at the transactions in the radix.ledger file, data follows with the 'some' length and value '00...'.

## Labels

docs
