### PR TITLE
NT-60: improve handling of failed connections

### DIFF
--- a/licence-header.txt
+++ b/licence-header.txt
@@ -1,4 +1,4 @@
-/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+/* Copyright $YEAR Radix Publishing Ltd incorporated in Jersey (Channel Islands).
  *
  * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:

--- a/licence-header.txt
+++ b/licence-header.txt
@@ -1,4 +1,4 @@
-/* Copyright $YEAR Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
  *
  * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/RadixNodeUri.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/RadixNodeUri.java
@@ -77,7 +77,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-public final class RadixNodeUri implements Comparable<RadixNodeUri>{
+public final class RadixNodeUri implements Comparable<RadixNodeUri> {
   private final String host;
   private final int port;
   private final String networkNodeHrp;

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBook.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBook.java
@@ -105,6 +105,13 @@ public final class AddressBook {
   public AddressBook(
       @Self RadixNodeUri self,
       EventDispatcher<PeerEvent> peerEventDispatcher,
+      AddressBookPersistence persistence) {
+    this(self, peerEventDispatcher, persistence, Clock.systemUTC());
+  }
+
+  public AddressBook(
+      RadixNodeUri self,
+      EventDispatcher<PeerEvent> peerEventDispatcher,
       AddressBookPersistence persistence,
       Clock clock) {
     this.self = Objects.requireNonNull(self);

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBook.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBook.java
@@ -210,7 +210,7 @@ public final class AddressBook {
   public void addOrUpdatePeerWithFailedConnection(RadixNodeUri radixNodeUri) {
     this.addOrUpdatePeerWithLatestConnectionStatus(radixNodeUri, LatestConnectionStatus.FAILURE);
 
-    if (!this.postponingManager.recordFailure(radixNodeUri)) {
+    if (!this.postponingManager.recordFailureAndCheckRecordPreservingStatus(radixNodeUri)) {
       synchronized (lock) {
         this.knownPeers.remove(radixNodeUri.getNodeId());
         this.persistence.removeEntry(radixNodeUri.getNodeId());

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBook.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBook.java
@@ -64,6 +64,8 @@
 
 package com.radixdlt.network.p2p.addressbook;
 
+import static java.util.function.Predicate.not;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
@@ -77,7 +79,6 @@ import com.radixdlt.network.p2p.addressbook.AddressBookEntry.PeerAddressEntry;
 import com.radixdlt.network.p2p.addressbook.AddressBookEntry.PeerAddressEntry.LatestConnectionStatus;
 import com.radixdlt.network.p2p.proxy.VerifiedProxyCertificate;
 import com.radixdlt.utils.Pair;
-
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -87,8 +88,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
-
-import static java.util.function.Predicate.not;
 
 /** Manages known peers network addresses and their metadata. */
 public final class AddressBook {

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/PeerPostponingManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/PeerPostponingManager.java
@@ -1,4 +1,4 @@
-/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+/* Copyright 2022 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
  *
  * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:
@@ -62,124 +62,76 @@
  * permissions under this License.
  */
 
-package com.radixdlt.network.p2p;
+package com.radixdlt.network.p2p.addressbook;
 
-import static java.util.Objects.requireNonNull;
+import com.radixdlt.network.p2p.RadixNodeUri;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.radixdlt.crypto.ECPublicKey;
-import com.radixdlt.identifiers.NodeAddressing;
-import com.radixdlt.networks.Addressing;
-import com.radixdlt.serialization.DeserializeException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.util.Objects;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
-public final class RadixNodeUri implements Comparable<RadixNodeUri>{
-  private final String host;
-  private final int port;
-  private final String networkNodeHrp;
-  private final NodeId nodeId;
+/**
+ * Maintain information about peers connections to which should be postponed.
+ *
+ * <p>Class implements simple exponential backoff strategy, doubling postpone time for every
+ * recorded failure.
+ */
+final class PeerPostponingManager {
+  private final Map<RadixNodeUri, PostponeInfo> postponedPeers = new HashMap<>();
+  private final Clock clock;
+  private final Duration initialPostpone;
+  private final Duration maxPostpone;
 
-  @JsonCreator
-  public static RadixNodeUri deserialize(byte[] uri)
-      throws URISyntaxException, DeserializeException {
-    return fromUri(new URI(new String(requireNonNull(uri))));
+  public PeerPostponingManager(Clock clock, Duration initialPostpone, Duration maxPostpone) {
+    this.clock = clock;
+    this.initialPostpone = initialPostpone;
+    this.maxPostpone = maxPostpone;
   }
 
-  public static RadixNodeUri fromPubKeyAndAddress(
-      int networkId, ECPublicKey publicKey, String host, int port) {
-    var hrp = Addressing.ofNetworkId(networkId).forNodes().getHrp();
-    return new RadixNodeUri(host, port, hrp, NodeId.fromPublicKey(publicKey));
+  public boolean recordFailure(RadixNodeUri uri) {
+    return postponedPeers.compute(uri, (key, postponeInfo) -> computePostponeInfo(postponeInfo))
+        != null;
   }
 
-  public static RadixNodeUri fromUri(URI uri) throws DeserializeException {
-    var hrpAndKey = NodeAddressing.parseUnknownHrp(uri.getUserInfo());
-    return new RadixNodeUri(
-        uri.getHost(),
-        uri.getPort(),
-        hrpAndKey.getFirst(),
-        NodeId.fromPublicKey(hrpAndKey.getSecond()));
+  private PostponeInfo computePostponeInfo(PostponeInfo postponeInfo) {
+    return postponeInfo == null
+        ? new PostponeInfo()
+        : postponeInfo.survivesFailure() ? postponeInfo : null;
   }
 
-  private RadixNodeUri(String host, int port, String networkNodeHrp, NodeId nodeId) {
-    if (port <= 0) {
-      throw new RuntimeException("Port must be a positive integer");
-    }
-    this.host = requireNonNull(host);
-    this.port = port;
-    this.networkNodeHrp = networkNodeHrp;
-    this.nodeId = requireNonNull(nodeId);
+  public void recordSuccess(RadixNodeUri uri) {
+    postponedPeers.remove(uri);
   }
 
-  public String getHost() {
-    return host;
+  public boolean shouldIgnore(RadixNodeUri uri) {
+    return Optional.ofNullable(postponedPeers.get(uri))
+        .map(PostponeInfo::shouldIgnore)
+        .orElse(false);
   }
 
-  public int getPort() {
-    return port;
+  private Instant now() {
+    return clock.instant();
   }
 
-  public NodeId getNodeId() {
-    return nodeId;
-  }
+  private final class PostponeInfo {
+    private final Instant firstFailure;
+    private Duration postponeDuration;
 
-  @JsonValue
-  private byte[] getSerializedValue() {
-    return getUriString().getBytes(StandardCharsets.UTF_8);
-  }
-
-  private String getUriString() {
-    return String.format("radix://%s@%s:%s", nodeAddress(), host, port);
-  }
-
-  public String nodeAddress() {
-    return NodeAddressing.of(networkNodeHrp, nodeId.getPublicKey());
-  }
-
-  public String getNetworkNodeHrp() {
-    return this.networkNodeHrp;
-  }
-
-  @Override
-  public String toString() {
-    return getUriString();
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final var that = (RadixNodeUri) o;
-    return port == that.port
-        && Objects.equals(host, that.host)
-        && Objects.equals(nodeId, that.nodeId)
-        && Objects.equals(networkNodeHrp, that.networkNodeHrp);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(host, port, nodeId, networkNodeHrp);
-  }
-
-  @Override
-  public int compareTo(RadixNodeUri other) {
-    int compare = nodeAddress().compareTo(other.nodeAddress());
-
-    if (compare == 0) {
-      compare = host.compareTo(other.host);
+    PostponeInfo() {
+      this.firstFailure = now();
+      this.postponeDuration = initialPostpone;
     }
 
-    if (compare == 0) {
-      compare = Integer.compare(port, other.port);
+    boolean survivesFailure() {
+      this.postponeDuration = postponeDuration.plus(postponeDuration);
+      return postponeDuration.compareTo(maxPostpone) <= 0;
     }
 
-    return compare;
+    boolean shouldIgnore() {
+      return firstFailure.plus(postponeDuration).compareTo(now()) >= 0;
+    }
   }
 }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/PeerPostponingManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/PeerPostponingManager.java
@@ -93,7 +93,7 @@ final class PeerPostponingManager {
     this.maxPostpone = maxPostpone;
   }
 
-  public boolean recordFailure(RadixNodeUri uri) {
+  public boolean recordFailureAndCheckRecordPreservingStatus(RadixNodeUri uri) {
     boolean survived = postponedPeers.compute(uri, this::computePostpone) != null;
 
     if (!survived) {
@@ -115,7 +115,7 @@ final class PeerPostponingManager {
   }
 
   private static PostponeInfo checkSurvival(PostponeInfo postponeInfo) {
-    return postponeInfo.survivesFailure() ? postponeInfo : null;
+    return postponeInfo.doublePostponeAndCheckIfStillShouldLive() ? postponeInfo : null;
   }
 
   public void recordSuccess(RadixNodeUri uri) {
@@ -151,7 +151,7 @@ final class PeerPostponingManager {
       this.postponeDuration = initialPostpone;
     }
 
-    boolean survivesFailure() {
+    boolean doublePostponeAndCheckIfStillShouldLive() {
       this.postponeDuration = postponeDuration.plus(postponeDuration);
       return postponeDuration.compareTo(maxPostpone) <= 0;
     }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/PeerPostponingManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/PeerPostponingManager.java
@@ -65,7 +65,6 @@
 package com.radixdlt.network.p2p.addressbook;
 
 import com.radixdlt.network.p2p.RadixNodeUri;
-
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/AddressBookTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/AddressBookTest.java
@@ -139,12 +139,11 @@ public final class AddressBookTest {
 
     sut.addOrUpdatePeerWithSuccessfulConnection(addr4);
     final var bestAddr5 = sut.findBestKnownAddressById(peerId).orElseThrow();
-    System.out.println(bestAddr5);
     assertTrue(bestAddr5 == addr3 || bestAddr5 == addr4);
   }
 
   @Test
-  public void address_book_should_not_show_failed_connection_uris_while_they_postponed() {
+  public void address_book_should_not_show_failed_connection_uris_while_they_are_postponed() {
     final var peerKey = ECKeyPair.generateNew().getPublicKey();
     final var peerId = NodeId.fromPublicKey(peerKey);
 

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/AddressBookTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/AddressBookTest.java
@@ -139,6 +139,7 @@ public final class AddressBookTest {
 
     sut.addOrUpdatePeerWithSuccessfulConnection(addr4);
     final var bestAddr5 = sut.findBestKnownAddressById(peerId).orElseThrow();
+    System.out.println(bestAddr5);
     assertTrue(bestAddr5 == addr3 || bestAddr5 == addr4);
   }
 

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/AddressBookTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/AddressBookTest.java
@@ -64,7 +64,12 @@
 
 package com.radixdlt.network.p2p.addressbook;
 
-import org.junit.Test;
+import static com.radixdlt.utils.TypedMocks.rmock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
 import com.radixdlt.crypto.ECKeyPair;
@@ -74,20 +79,12 @@ import com.radixdlt.network.p2p.NodeId;
 import com.radixdlt.network.p2p.RadixNodeUri;
 import com.radixdlt.network.p2p.proxy.ProxyCertificate;
 import com.radixdlt.network.p2p.proxy.ProxyCertificateData;
-
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import static com.radixdlt.utils.TypedMocks.rmock;
+import org.junit.Test;
 
 public final class AddressBookTest {
 
@@ -220,7 +217,8 @@ public final class AddressBookTest {
   }
 
   private AddressBook createAddressBook(RadixNodeUri self) {
-    return new AddressBook(self, rmock(EventDispatcher.class), new InMemoryAddressBookPersistence(), createClock());
+    return new AddressBook(
+        self, rmock(EventDispatcher.class), new InMemoryAddressBookPersistence(), createClock());
   }
 
   private static RadixNodeUri createNodeUri(int network, String host) {

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/PeerPostponingManagerTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/PeerPostponingManagerTest.java
@@ -64,18 +64,17 @@
 
 package com.radixdlt.network.p2p.addressbook;
 
-import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.network.p2p.RadixNodeUri;
-
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.Test;
 
 public class PeerPostponingManagerTest {
   private final RadixNodeUri peer1 = createNodeUri("1.1.1.1");
@@ -92,9 +91,13 @@ public class PeerPostponingManagerTest {
 
     when(clock.instant()).thenReturn(time0, time1, time2, time3);
 
-    assertTrue(manager.recordFailure(peer1)); //First time it should survive, record is missing
-    assertTrue(manager.recordFailure(peer1)); //Second time it should survive, computed duration now is 2 min
-    assertFalse(manager.recordFailure(peer1)); //Should not survive, computed duration (4 min) is above limit (3 min)
+    assertTrue(manager.recordFailure(peer1)); // First time it should survive, record is missing
+    assertTrue(
+        manager.recordFailure(
+            peer1)); // Second time it should survive, computed duration now is 2 min
+    assertFalse(
+        manager.recordFailure(
+            peer1)); // Should not survive, computed duration (4 min) is above limit (3 min)
   }
 
   @Test
@@ -114,6 +117,7 @@ public class PeerPostponingManagerTest {
   }
 
   private static RadixNodeUri createNodeUri(String host) {
-    return RadixNodeUri.fromPubKeyAndAddress(1, ECKeyPair.generateNew().getPublicKey(), host, 30000);
+    return RadixNodeUri.fromPubKeyAndAddress(
+        1, ECKeyPair.generateNew().getPublicKey(), host, 30000);
   }
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/PeerPostponingManagerTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/PeerPostponingManagerTest.java
@@ -82,15 +82,15 @@ public class PeerPostponingManagerTest {
     var manager = new PeerPostponingManager(clock, Duration.ofMinutes(1), Duration.ofMinutes(3));
 
     // First time it should survive, record is missing
-    assertTrue(manager.recordFailure(peer1));
+    assertTrue(manager.recordFailureAndCheckRecordPreservingStatus(peer1));
 
     // Second time it should survive, computed duration now is 2 min
     clock.next(Duration.ofSeconds(30));
-    assertTrue(manager.recordFailure(peer1));
+    assertTrue(manager.recordFailureAndCheckRecordPreservingStatus(peer1));
 
     // Should not survive, computed duration (4 min) is above limit (3 min)
     clock.next(Duration.ofSeconds(30));
-    assertFalse(manager.recordFailure(peer1));
+    assertFalse(manager.recordFailureAndCheckRecordPreservingStatus(peer1));
   }
 
   @Test
@@ -98,7 +98,7 @@ public class PeerPostponingManagerTest {
     var clock = new ControlledClock();
     var manager = new PeerPostponingManager(clock, Duration.ofMinutes(1), Duration.ofMinutes(3));
 
-    assertTrue(manager.recordFailure(peer1));
+    assertTrue(manager.recordFailureAndCheckRecordPreservingStatus(peer1));
 
     clock.next(Duration.ofSeconds(30));
     assertTrue(manager.shouldIgnore(peer1));
@@ -119,10 +119,10 @@ public class PeerPostponingManagerTest {
     var clock = new ControlledClock();
     var manager = new PeerPostponingManager(clock, Duration.ofMinutes(1), Duration.ofMinutes(3));
 
-    manager.recordFailure(peer1);
+    manager.recordFailureAndCheckRecordPreservingStatus(peer1);
 
     clock.next(Duration.ofSeconds(30));
-    manager.recordFailure(peer2);
+    manager.recordFailureAndCheckRecordPreservingStatus(peer2);
 
     // Both addresses are postponed now
     clock.next(Duration.ofSeconds(30));


### PR DESCRIPTION
Changed approach to handling of failed peer connection. 
The algorithm looks as follows:

With every failed connection attempt, peer is ignored for consequently increased time interval. Initial delay is set to 1 and then doubled with failed connection. Once the calculated interval exceeds 1hr, peer is completely removed from the address book.

This approach provides enough time for the failed node to restore (also about 1hr), but if the issue persists, the peer is removed, so there are no stall records in the address book. This should eliminate issues with failed peers, which are restored functioning with another IP address.

Known issue:
- If a peer has more than one address and one succeeds while others failed but not expired, failed addresses may remain stored. Such a "leftovers" will be cleared if peer will disconnect and then successfully reconnect after some time (longer than 1hr). Should not be an issue in practice.
