### PR TITLE
Eliminate technical debt

### DIFF
--- a/licence-header.txt
+++ b/licence-header.txt
@@ -1,4 +1,4 @@
-/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+/* Copyright $YEAR Radix Publishing Ltd incorporated in Jersey (Channel Islands).
  *
  * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:

--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/monitors/application/CommittedChecker.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/monitors/application/CommittedChecker.java
@@ -101,7 +101,7 @@ public class CommittedChecker implements TestInvariant {
                     .serialize()
                     .filter(
                         e ->
-                            e.getCommitted().stream()
+                            e.committed().stream()
                                 .flatMap(PreparedVertex::getTxns)
                                 .anyMatch(c -> Arrays.equals(c.getPayload(), txn.getPayload())))
                     .timeout(10, TimeUnit.SECONDS)

--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/monitors/consensus/LivenessInvariant.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/monitors/consensus/LivenessInvariant.java
@@ -102,7 +102,7 @@ public class LivenessInvariant implements TestInvariant {
                   BFTHighQCUpdate.class);
               nodeEvents.addListener(
                   (node, committed) -> {
-                    emitter.onNext(committed.getVertexStoreState().getHighQC().highestQC());
+                    emitter.onNext(committed.vertexStoreState().getHighQC().highestQC());
                   },
                   BFTCommittedUpdate.class);
             })

--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/monitors/epochs/EpochViewInvariant.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/monitors/epochs/EpochViewInvariant.java
@@ -89,8 +89,7 @@ public class EpochViewInvariant implements TestInvariant {
                 this.commits.addListener(
                     (node, commit) -> emitter.onNext(commit), BFTCommittedUpdate.class))
         .serialize()
-        .concatMap(
-            committedUpdate -> Observable.fromStream(committedUpdate.committed().stream()))
+        .concatMap(committedUpdate -> Observable.fromStream(committedUpdate.committed().stream()))
         .flatMap(
             vertex -> {
               final View view = vertex.getView();

--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/monitors/epochs/EpochViewInvariant.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/monitors/epochs/EpochViewInvariant.java
@@ -90,7 +90,7 @@ public class EpochViewInvariant implements TestInvariant {
                     (node, commit) -> emitter.onNext(commit), BFTCommittedUpdate.class))
         .serialize()
         .concatMap(
-            committedUpdate -> Observable.fromStream(committedUpdate.getCommitted().stream()))
+            committedUpdate -> Observable.fromStream(committedUpdate.committed().stream()))
         .flatMap(
             vertex -> {
               final View view = vertex.getView();

--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/monitors/ledger/ConsensusToLedgerCommittedInvariant.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/distributed/simulation/monitors/ledger/ConsensusToLedgerCommittedInvariant.java
@@ -110,7 +110,7 @@ public class ConsensusToLedgerCommittedInvariant implements TestInvariant {
         .concatMap(
             committedUpdate ->
                 Observable.fromStream(
-                    committedUpdate.getCommitted().stream()
+                    committedUpdate.committed().stream()
                         .flatMap(PreparedVertex::successfulCommands)))
         .flatMapMaybe(
             txn ->

--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/invariants/SafetyChecker.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/invariants/SafetyChecker.java
@@ -155,7 +155,7 @@ public final class SafetyChecker {
   }
 
   public Optional<TestInvariantError> process(BFTNode node, BFTCommittedUpdate committedUpdate) {
-    ImmutableList<PreparedVertex> vertices = committedUpdate.getCommitted();
+    ImmutableList<PreparedVertex> vertices = committedUpdate.committed();
     for (PreparedVertex vertex : vertices) {
       Optional<TestInvariantError> maybeError = process(node, vertex.getVertex());
       if (maybeError.isPresent()) {

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/DispatcherModule.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/DispatcherModule.java
@@ -428,15 +428,15 @@ public class DispatcherModule extends AbstractModule {
       SystemCounters systemCounters) {
     if (asyncProcessors.isEmpty()) {
       return commit -> {
-        systemCounters.add(CounterType.BFT_COMMITTED_VERTICES, commit.getCommitted().size());
-        systemCounters.set(CounterType.BFT_VERTEX_STORE_SIZE, commit.getVertexStoreSize());
+        systemCounters.add(CounterType.BFT_COMMITTED_VERTICES, commit.committed().size());
+        systemCounters.set(CounterType.BFT_VERTEX_STORE_SIZE, commit.vertexStoreSize());
         processors.forEach(e -> e.process(commit));
       };
     } else {
       var dispatcher = environment.getDispatcher(BFTCommittedUpdate.class);
       return commit -> {
-        systemCounters.add(CounterType.BFT_COMMITTED_VERTICES, commit.getCommitted().size());
-        systemCounters.set(CounterType.BFT_VERTEX_STORE_SIZE, commit.getVertexStoreSize());
+        systemCounters.add(CounterType.BFT_COMMITTED_VERTICES, commit.committed().size());
+        systemCounters.set(CounterType.BFT_VERTEX_STORE_SIZE, commit.vertexStoreSize());
         processors.forEach(e -> e.process(commit));
         dispatcher.dispatch(commit);
       };

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/LedgerHeader.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/LedgerHeader.java
@@ -73,7 +73,6 @@ import com.google.common.collect.ImmutableSet;
 import com.radixdlt.consensus.bft.BFTValidator;
 import com.radixdlt.consensus.bft.BFTValidatorSet;
 import com.radixdlt.consensus.bft.View;
-import com.radixdlt.crypto.HashUtils;
 import com.radixdlt.ledger.AccumulatorState;
 import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.serialization.DsonOutput.Output;
@@ -138,12 +137,6 @@ public final class LedgerHeader {
     this.accumulatorState = requireNonNull(accumulatorState);
     this.nextValidators = nextValidators;
     this.timestamp = timestamp;
-  }
-
-  // TODO: used only for tests, move elsewhere https://radixdlt.atlassian.net/browse/NT-2
-  public static LedgerHeader mocked() {
-    return new LedgerHeader(
-        0, View.genesis(), new AccumulatorState(0, HashUtils.zero256()), 0, null);
   }
 
   public static LedgerHeader genesis(

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/bft/BFTCommittedUpdate.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/bft/BFTCommittedUpdate.java
@@ -65,33 +65,10 @@
 package com.radixdlt.consensus.bft;
 
 import com.google.common.collect.ImmutableList;
-import java.util.Objects;
 
 /** Vertex Store update of committed vertices */
-public final class BFTCommittedUpdate {
-  private final ImmutableList<PreparedVertex> committed;
-  private final VerifiedVertexStoreState vertexStoreState;
-
-  private BFTCommittedUpdate(
-      ImmutableList<PreparedVertex> committed, VerifiedVertexStoreState vertexStoreState) {
-    this.committed = Objects.requireNonNull(committed);
-    this.vertexStoreState = Objects.requireNonNull(vertexStoreState);
-  }
-
-  public static BFTCommittedUpdate create(
-      ImmutableList<PreparedVertex> committed, VerifiedVertexStoreState vertexStoreState) {
-    return new BFTCommittedUpdate(committed, vertexStoreState);
-  }
-
-  public int getVertexStoreSize() {
+public record BFTCommittedUpdate(ImmutableList<PreparedVertex> committed, VerifiedVertexStoreState vertexStoreState) {
+  public int vertexStoreSize() {
     return vertexStoreState.getVertices().size();
-  }
-
-  public ImmutableList<PreparedVertex> getCommitted() {
-    return committed;
-  }
-
-  public VerifiedVertexStoreState getVertexStoreState() {
-    return vertexStoreState;
   }
 }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/bft/BFTCommittedUpdate.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/bft/BFTCommittedUpdate.java
@@ -67,7 +67,8 @@ package com.radixdlt.consensus.bft;
 import com.google.common.collect.ImmutableList;
 
 /** Vertex Store update of committed vertices */
-public record BFTCommittedUpdate(ImmutableList<PreparedVertex> committed, VerifiedVertexStoreState vertexStoreState) {
+public record BFTCommittedUpdate(
+    ImmutableList<PreparedVertex> committed, VerifiedVertexStoreState vertexStoreState) {
   public int vertexStoreSize() {
     return vertexStoreState.getVertices().size();
   }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/bft/BFTCommittedUpdate.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/bft/BFTCommittedUpdate.java
@@ -65,31 +65,22 @@
 package com.radixdlt.consensus.bft;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.hash.HashCode;
 import java.util.Objects;
 
 /** Vertex Store update of committed vertices */
 public final class BFTCommittedUpdate {
-  private final ImmutableSet<HashCode>
-      pruned; // TODO: remove unused https://radixdlt.atlassian.net/browse/NT-5
   private final ImmutableList<PreparedVertex> committed;
   private final VerifiedVertexStoreState vertexStoreState;
 
   private BFTCommittedUpdate(
-      ImmutableSet<HashCode> pruned,
-      ImmutableList<PreparedVertex> committed,
-      VerifiedVertexStoreState vertexStoreState) {
-    this.pruned = Objects.requireNonNull(pruned);
+      ImmutableList<PreparedVertex> committed, VerifiedVertexStoreState vertexStoreState) {
     this.committed = Objects.requireNonNull(committed);
     this.vertexStoreState = Objects.requireNonNull(vertexStoreState);
   }
 
   public static BFTCommittedUpdate create(
-      ImmutableSet<HashCode> pruned,
-      ImmutableList<PreparedVertex> committed,
-      VerifiedVertexStoreState vertexStoreState) {
-    return new BFTCommittedUpdate(pruned, committed, vertexStoreState);
+      ImmutableList<PreparedVertex> committed, VerifiedVertexStoreState vertexStoreState) {
+    return new BFTCommittedUpdate(committed, vertexStoreState);
   }
 
   public int getVertexStoreSize() {

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/bft/VertexStore.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/consensus/bft/VertexStore.java
@@ -394,7 +394,7 @@ public final class VertexStore {
     }
 
     VerifiedVertexStoreState vertexStoreState = getState();
-    this.bftCommittedDispatcher.dispatch(BFTCommittedUpdate.create(path, vertexStoreState));
+    this.bftCommittedDispatcher.dispatch(new BFTCommittedUpdate(path, vertexStoreState));
   }
 
   public LinkedList<PreparedVertex> getPathFromRoot(HashCode vertexId) {

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
@@ -276,15 +276,15 @@ public final class StateComputerLedger implements Ledger, NextTxnsGenerator {
   public EventProcessor<BFTCommittedUpdate> bftCommittedUpdateEventProcessor() {
     return committedUpdate -> {
       final ImmutableList<Txn> txns =
-          committedUpdate.getCommitted().stream()
+          committedUpdate.committed().stream()
               .flatMap(PreparedVertex::successfulCommands)
               .map(PreparedTxn::txn)
               .collect(ImmutableList.toImmutableList());
-      var proof = committedUpdate.getVertexStoreState().getRootHeader();
+      var proof = committedUpdate.vertexStoreState().getRootHeader();
       var verifiedTxnsAndProof = VerifiedTxnsAndProof.create(txns, proof);
 
       // TODO: Make these two atomic (RPNV1-827)
-      this.commit(verifiedTxnsAndProof, committedUpdate.getVertexStoreState());
+      this.commit(verifiedTxnsAndProof, committedUpdate.vertexStoreState());
     };
   }
 

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/systeminfo/InMemorySystemInfo.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/systeminfo/InMemorySystemInfo.java
@@ -119,7 +119,7 @@ public final class InMemorySystemInfo {
 
   public EventProcessor<BFTCommittedUpdate> bftCommittedUpdateEventProcessor() {
     return update -> {
-      this.highQC.set(update.getVertexStoreState().getHighQC().highestQC());
+      this.highQC.set(update.vertexStoreState().getHighQC().highestQC());
     };
   }
 

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/HighQCTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/HighQCTest.java
@@ -84,7 +84,7 @@ public class HighQCTest extends SerializeObject<HighQC> {
   private static HighQC get() {
     View view = View.of(1234567891L);
     HashCode id = HashUtils.random256();
-    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.get();
     BFTHeader header = new BFTHeader(view, id, ledgerHeader);
     BFTHeader parent = new BFTHeader(View.of(1234567890L), HashUtils.random256(), ledgerHeader);
     BFTHeader commit = new BFTHeader(View.of(1234567889L), HashUtils.random256(), ledgerHeader);

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/HighQCTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/HighQCTest.java
@@ -70,6 +70,7 @@ import static org.mockito.Mockito.mock;
 import com.google.common.hash.HashCode;
 import com.radixdlt.consensus.bft.View;
 import com.radixdlt.crypto.HashUtils;
+import com.radixdlt.utils.LedgerHeaderMock;
 import java.util.Optional;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
@@ -83,7 +84,7 @@ public class HighQCTest extends SerializeObject<HighQC> {
   private static HighQC get() {
     View view = View.of(1234567891L);
     HashCode id = HashUtils.random256();
-    LedgerHeader ledgerHeader = LedgerHeader.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
     BFTHeader header = new BFTHeader(view, id, ledgerHeader);
     BFTHeader parent = new BFTHeader(View.of(1234567890L), HashUtils.random256(), ledgerHeader);
     BFTHeader commit = new BFTHeader(View.of(1234567889L), HashUtils.random256(), ledgerHeader);

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/bft/VertexStoreTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/consensus/bft/VertexStoreTest.java
@@ -234,8 +234,8 @@ public class VertexStoreTest {
         .dispatch(
             argThat(
                 u ->
-                    u.getCommitted().size() == 1
-                        && u.getCommitted().get(0).getVertex().equals(vertices.get(0))));
+                    u.committed().size() == 1
+                        && u.committed().get(0).getVertex().equals(vertices.get(0))));
   }
 
   @Test

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesErrorResponseMessageSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesErrorResponseMessageSerializeTest.java
@@ -83,7 +83,7 @@ public class GetVerticesErrorResponseMessageSerializeTest
 
   private static GetVerticesErrorResponseMessage get() {
     var accumulatorState = new AccumulatorState(0, HashUtils.zero256());
-    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.get();
     VerifiedVertex verifiedVertex =
         new VerifiedVertex(UnverifiedVertex.createGenesis(ledgerHeader), HashUtils.zero256());
     QuorumCertificate qc = QuorumCertificate.ofGenesis(verifiedVertex, ledgerHeader);

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesResponseMessageSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesResponseMessageSerializeTest.java
@@ -67,6 +67,7 @@ package com.radixdlt.middleware2.network;
 import com.google.common.collect.ImmutableList;
 import com.radixdlt.consensus.LedgerHeader;
 import com.radixdlt.consensus.UnverifiedVertex;
+import com.radixdlt.utils.LedgerHeaderMock;
 import org.radix.serialization.SerializeMessageObject;
 
 public class GetVerticesResponseMessageSerializeTest
@@ -76,7 +77,7 @@ public class GetVerticesResponseMessageSerializeTest
   }
 
   private static GetVerticesResponseMessage get() {
-    LedgerHeader ledgerHeader = LedgerHeader.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
     UnverifiedVertex genesisVertex = UnverifiedVertex.createGenesis(ledgerHeader);
     return new GetVerticesResponseMessage(ImmutableList.of(genesisVertex));
   }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesResponseMessageSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/middleware2/network/GetVerticesResponseMessageSerializeTest.java
@@ -77,7 +77,7 @@ public class GetVerticesResponseMessageSerializeTest
   }
 
   private static GetVerticesResponseMessage get() {
-    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.get();
     UnverifiedVertex genesisVertex = UnverifiedVertex.createGenesis(ledgerHeader);
     return new GetVerticesResponseMessage(ImmutableList.of(genesisVertex));
   }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/utils/LedgerHeaderMock.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/utils/LedgerHeaderMock.java
@@ -1,4 +1,4 @@
-/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+/* Copyright 2022 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
  *
  * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:
@@ -62,33 +62,15 @@
  * permissions under this License.
  */
 
-package com.radixdlt.middleware2.network;
+package com.radixdlt.utils;
 
-import com.radixdlt.consensus.HighQC;
 import com.radixdlt.consensus.LedgerHeader;
-import com.radixdlt.consensus.QuorumCertificate;
-import com.radixdlt.consensus.UnverifiedVertex;
-import com.radixdlt.consensus.bft.VerifiedVertex;
+import com.radixdlt.consensus.bft.View;
 import com.radixdlt.crypto.HashUtils;
 import com.radixdlt.ledger.AccumulatorState;
-import com.radixdlt.utils.LedgerHeaderMock;
-import java.util.Optional;
-import org.radix.serialization.SerializeMessageObject;
 
-public class GetVerticesErrorResponseMessageSerializeTest
-    extends SerializeMessageObject<GetVerticesErrorResponseMessage> {
-  public GetVerticesErrorResponseMessageSerializeTest() {
-    super(GetVerticesErrorResponseMessage.class, GetVerticesErrorResponseMessageSerializeTest::get);
-  }
-
-  private static GetVerticesErrorResponseMessage get() {
-    var accumulatorState = new AccumulatorState(0, HashUtils.zero256());
-    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
-    VerifiedVertex verifiedVertex =
-        new VerifiedVertex(UnverifiedVertex.createGenesis(ledgerHeader), HashUtils.zero256());
-    QuorumCertificate qc = QuorumCertificate.ofGenesis(verifiedVertex, ledgerHeader);
-    HighQC highQC = HighQC.from(qc, qc, Optional.empty());
-    final var request = new GetVerticesRequestMessage(HashUtils.random256(), 3);
-    return new GetVerticesErrorResponseMessage(highQC, request);
+public class LedgerHeaderMock {
+  public static LedgerHeader mocked() {
+    return LedgerHeader.create(0, View.genesis(), new AccumulatorState(0, HashUtils.zero256()), 0);
   }
 }

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/utils/LedgerHeaderMock.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/utils/LedgerHeaderMock.java
@@ -70,7 +70,7 @@ import com.radixdlt.crypto.HashUtils;
 import com.radixdlt.ledger.AccumulatorState;
 
 public class LedgerHeaderMock {
-  public static LedgerHeader mocked() {
+  public static LedgerHeader get() {
     return LedgerHeader.create(0, View.genesis(), new AccumulatorState(0, HashUtils.zero256()), 0);
   }
 }

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/BFTHeaderSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/BFTHeaderSerializeTest.java
@@ -77,7 +77,7 @@ public class BFTHeaderSerializeTest extends SerializeObject<BFTHeader> {
 
   private static BFTHeader get() {
     View view = View.of(1234567890L);
-    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.get();
     return new BFTHeader(view, HashUtils.random256(), ledgerHeader);
   }
 }

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/BFTHeaderSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/BFTHeaderSerializeTest.java
@@ -68,6 +68,7 @@ import com.radixdlt.consensus.BFTHeader;
 import com.radixdlt.consensus.LedgerHeader;
 import com.radixdlt.consensus.bft.View;
 import com.radixdlt.crypto.HashUtils;
+import com.radixdlt.utils.LedgerHeaderMock;
 
 public class BFTHeaderSerializeTest extends SerializeObject<BFTHeader> {
   public BFTHeaderSerializeTest() {
@@ -76,7 +77,7 @@ public class BFTHeaderSerializeTest extends SerializeObject<BFTHeader> {
 
   private static BFTHeader get() {
     View view = View.of(1234567890L);
-    LedgerHeader ledgerHeader = LedgerHeader.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
     return new BFTHeader(view, HashUtils.random256(), ledgerHeader);
   }
 }

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
@@ -78,6 +78,7 @@ import com.radixdlt.consensus.bft.View;
 import com.radixdlt.crypto.ECDSASignature;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.crypto.HashUtils;
+import com.radixdlt.utils.LedgerHeaderMock;
 import java.util.List;
 import java.util.Optional;
 
@@ -90,7 +91,7 @@ public class ProposalSerializeTest extends SerializeObject<Proposal> {
     View view = View.of(1234567891L);
     HashCode id = HashUtils.random256();
 
-    LedgerHeader ledgerHeader = LedgerHeader.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
     BFTHeader header = new BFTHeader(view, id, ledgerHeader);
     BFTHeader parent = new BFTHeader(View.of(1234567890L), HashUtils.random256(), ledgerHeader);
     VoteData voteData = new VoteData(header, parent, null);

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/ProposalSerializeTest.java
@@ -91,7 +91,7 @@ public class ProposalSerializeTest extends SerializeObject<Proposal> {
     View view = View.of(1234567891L);
     HashCode id = HashUtils.random256();
 
-    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.get();
     BFTHeader header = new BFTHeader(view, id, ledgerHeader);
     BFTHeader parent = new BFTHeader(View.of(1234567890L), HashUtils.random256(), ledgerHeader);
     VoteData voteData = new VoteData(header, parent, null);

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/UnverifiedVertexSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/UnverifiedVertexSerializeTest.java
@@ -74,6 +74,7 @@ import com.radixdlt.consensus.VoteData;
 import com.radixdlt.consensus.bft.BFTNode;
 import com.radixdlt.consensus.bft.View;
 import com.radixdlt.crypto.HashUtils;
+import com.radixdlt.utils.LedgerHeaderMock;
 import java.util.List;
 
 public class UnverifiedVertexSerializeTest extends SerializeObject<UnverifiedVertex> {
@@ -83,7 +84,7 @@ public class UnverifiedVertexSerializeTest extends SerializeObject<UnverifiedVer
 
   private static UnverifiedVertex get() {
     View view = View.of(1234567891L);
-    LedgerHeader ledgerHeader = LedgerHeader.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
     BFTHeader header = new BFTHeader(view, HashUtils.random256(), ledgerHeader);
     BFTHeader parent = new BFTHeader(View.of(1234567890L), HashUtils.random256(), ledgerHeader);
     VoteData voteData = new VoteData(header, parent, null);

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/UnverifiedVertexSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/UnverifiedVertexSerializeTest.java
@@ -84,7 +84,7 @@ public class UnverifiedVertexSerializeTest extends SerializeObject<UnverifiedVer
 
   private static UnverifiedVertex get() {
     View view = View.of(1234567891L);
-    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.get();
     BFTHeader header = new BFTHeader(view, HashUtils.random256(), ledgerHeader);
     BFTHeader parent = new BFTHeader(View.of(1234567890L), HashUtils.random256(), ledgerHeader);
     VoteData voteData = new VoteData(header, parent, null);

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/VoteDataSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/VoteDataSerializeTest.java
@@ -78,7 +78,7 @@ public class VoteDataSerializeTest extends SerializeObject<VoteData> {
 
   private static VoteData get() {
     View view = View.of(1234567890L);
-    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.get();
     BFTHeader committed = new BFTHeader(view, HashUtils.random256(), ledgerHeader);
     BFTHeader parent = new BFTHeader(view.next(), HashUtils.random256(), ledgerHeader);
     BFTHeader proposed = new BFTHeader(view.next().next(), HashUtils.random256(), ledgerHeader);

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/VoteDataSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/VoteDataSerializeTest.java
@@ -69,6 +69,7 @@ import com.radixdlt.consensus.LedgerHeader;
 import com.radixdlt.consensus.VoteData;
 import com.radixdlt.consensus.bft.View;
 import com.radixdlt.crypto.HashUtils;
+import com.radixdlt.utils.LedgerHeaderMock;
 
 public class VoteDataSerializeTest extends SerializeObject<VoteData> {
   public VoteDataSerializeTest() {
@@ -77,7 +78,7 @@ public class VoteDataSerializeTest extends SerializeObject<VoteData> {
 
   private static VoteData get() {
     View view = View.of(1234567890L);
-    LedgerHeader ledgerHeader = LedgerHeader.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
     BFTHeader committed = new BFTHeader(view, HashUtils.random256(), ledgerHeader);
     BFTHeader parent = new BFTHeader(view.next(), HashUtils.random256(), ledgerHeader);
     BFTHeader proposed = new BFTHeader(view.next().next(), HashUtils.random256(), ledgerHeader);

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/VoteSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/VoteSerializeTest.java
@@ -89,7 +89,7 @@ public class VoteSerializeTest extends SerializeObject<Vote> {
     View view = View.of(1234567891L);
     HashCode id = HashUtils.random256();
 
-    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.get();
     BFTHeader header = new BFTHeader(view, id, ledgerHeader);
     BFTHeader parent = new BFTHeader(View.of(1234567890L), HashUtils.random256(), ledgerHeader);
     VoteData voteData = new VoteData(header, parent, null);

--- a/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/VoteSerializeTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/org/radix/serialization/VoteSerializeTest.java
@@ -77,6 +77,7 @@ import com.radixdlt.consensus.bft.View;
 import com.radixdlt.crypto.ECDSASignature;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.crypto.HashUtils;
+import com.radixdlt.utils.LedgerHeaderMock;
 import java.util.Optional;
 
 public class VoteSerializeTest extends SerializeObject<Vote> {
@@ -88,7 +89,7 @@ public class VoteSerializeTest extends SerializeObject<Vote> {
     View view = View.of(1234567891L);
     HashCode id = HashUtils.random256();
 
-    LedgerHeader ledgerHeader = LedgerHeader.mocked();
+    LedgerHeader ledgerHeader = LedgerHeaderMock.mocked();
     BFTHeader header = new BFTHeader(view, id, ledgerHeader);
     BFTHeader parent = new BFTHeader(View.of(1234567890L), HashUtils.random256(), ledgerHeader);
     VoteData voteData = new VoteData(header, parent, null);


### PR DESCRIPTION
This PR addresses 2 issues:
 - NT-2 Move LedgerHeader.mocked() somewhere into test infrastructure
 - NT-5 Remove unused field in BFTCommittedUpdate
 