### PR TITLE
Postman collection publishing

### DIFF
--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -35,7 +35,7 @@ jobs:
       #  run: sed -i 's/(network-name)/(rcnet)/' openapi-spec.json
       - name: Generate rcnet collection
         run: |
-          npx @apideck/portman -l ./${{ github.workspace }}/gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
+          npx @apideck/portman -l .${{ github.workspace }}/gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
             -b https://rcnet.radixdlt.com
       - name: Setup localnet credentials
         uses: DamianReeves/write-file-action@v1.0

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           repository: radixdlt/radixdlt-network-gateway
           path: gateway-api-spec.yaml
+      - run: |
+          ls ${{ github.workspace }}
+      - run: |
+          ls
       - name: Setup Postman credentials
         uses: DamianReeves/write-file-action@v1.0
         with:

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -44,11 +44,11 @@ jobs:
       - name: Update Postman's Core API collection from the spec
         run: |
           npx @apideck/portman -l core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml \
-            --postmanUid 14449947-fb9a194f-6341-41d7-a826-8c701f0fbf57 \
+            --postmanUid 14449947-f288f14a-5deb-4427-bde5-52c2f4c696de \
             --syncPostman true --envFile .env --cliOptionsFile cliopts.json
       - name: Download the collection
         run: |
-          curl -X GET -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" https://api.getpostman.com/collections/14449947-fb9a194f-6341-41d7-a826-8c701f0fbf57 > tmp.core.collection.json
+          curl -X GET -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" https://api.getpostman.com/collections/14449947-f288f14a-5deb-4427-bde5-52c2f4c696de > tmp.core.collection.json
       - name: Add a timestamp to the name
         run: |
           sed -i 's/"name":".*","description":"This API/"name":"Core API (develop) ${{steps.date.outputs.date}} UTC","description":"This API/' tmp.core.collection.json
@@ -58,7 +58,7 @@ jobs:
       - name: Update the collection
         run: |
           curl -X PUT -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" -H "Content-Type: application/json" \
-             https://api.getpostman.com/collections/14449947-fb9a194f-6341-41d7-a826-8c701f0fbf57 --data "@tmp.core.collection.json"
+             https://api.getpostman.com/collections/14449947-f288f14a-5deb-4427-bde5-52c2f4c696de --data "@tmp.core.collection.json"
 
 #      - name: Create Portman configuration for System API
 #        uses: DamianReeves/write-file-action@v1.0

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -21,10 +21,6 @@ jobs:
         with:
           repository: radixdlt/radixdlt-network-gateway
           path: gateway-api-spec.yaml
-      - run: |
-          ls ${{ github.workspace }}
-      - run: |
-          ls
       - name: Setup Postman credentials
         uses: DamianReeves/write-file-action@v1.0
         with:
@@ -33,9 +29,11 @@ jobs:
           write-mode: append
       #- name: Rename OpenApi spec name for rcnet
       #  run: sed -i 's/(network-name)/(rcnet)/' openapi-spec.json
+      - run: |
+          ls
       - name: Generate rcnet collection
         run: |
-          npx @apideck/portman -l .${{ github.workspace }}/gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
+          npx @apideck/portman -l ./gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
             -b https://rcnet.radixdlt.com
       - name: Setup localnet credentials
         uses: DamianReeves/write-file-action@v1.0

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -29,6 +29,8 @@ jobs:
           write-mode: append
       #- name: Rename OpenApi spec name for rcnet
       #  run: sed -i 's/(network-name)/(rcnet)/' openapi-spec.json
+      - run: |
+          cat .env-rcnet
       - name: Generate rcnet collection
         run: |
           npx @apideck/portman -l ./gateway/gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -42,17 +42,17 @@ jobs:
         with:
           repository: radixdlt/radixdlt
           path: core
+      - name: Change OpenApi version in the Core API spec
+        run: sed -i 's/(3.0.0)/(3.1.0)/' core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml
       - name: Create Portman configuration for Core API
         uses: DamianReeves/write-file-action@v1.0
         with:
           path: cliopts.json
           contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"Core API (develop)"}'
           write-mode: overwrite
-      - name: Change OpenApi version in the Core API spec
-        run: sed -i 's/(3.0.0)/(3.1.0)/' radixdlt/radixdlt/develop/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml
       - name: Generate and upload Postman's Core API collection
         run: |
-          npx @apideck/portman -l radixdlt/radixdlt/develop/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml \
+          npx @apideck/portman -l core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml \
             --postmanUid 14449947-fb9a194f-6341-41d7-a826-8c701f0fbf57 \
             --syncPostman true --envFile .env --cliOptionsFile cliopts.json
       - name: Create Portman configuration for Core API
@@ -63,6 +63,6 @@ jobs:
           write-mode: overwrite
       - name: Generate and upload Postman's System API collection
         run: |
-          npx @apideck/portman -l radixdlt/radixdlt/develop/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/system/api.yaml \
+          npx @apideck/portman -l core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/system/api.yaml \
             --postmanUid 14449947-cbede7fb-7361-4d91-becc-e1e10e0b2454 \
             --syncPostman true --envFile .env --cliOptionsFile cliopts.json

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -16,11 +16,12 @@ jobs:
     environment: Postman
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout openapi spec
+      - name: Checkout gateway's openapi spec
         uses: actions/checkout@v2
         with:
-          repository: Theoklitos/openapi-spec
-      - name: Setup rcnet credentials
+          repository: radixdlt/radixdlt-network-gateway
+          path: gateway-api-spec.yaml
+      - name: Setup Postman credentials
         uses: DamianReeves/write-file-action@v1.0
         with:
           path: .env-rcnet

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: radixdlt/radixdlt-network-gateway
-          path: gateway-api-spec.yaml
+          path: gateway
       - name: Setup Postman credentials
         uses: DamianReeves/write-file-action@v1.0
         with:
@@ -29,13 +29,10 @@ jobs:
           write-mode: append
       #- name: Rename OpenApi spec name for rcnet
       #  run: sed -i 's/(network-name)/(rcnet)/' openapi-spec.json
-      - run: |
-          ls -la
-      - run: find .
       - name: Generate rcnet collection
         run: |
-          npx @apideck/portman -l ./gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
-            -b https://rcnet.radixdlt.com
+          npx @apideck/portman -l ./gateway/gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
+            -b https://rcnet-gateway.radixdlt.com
       - name: Setup localnet credentials
         uses: DamianReeves/write-file-action@v1.0
         with:

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -31,6 +31,7 @@ jobs:
       #  run: sed -i 's/(network-name)/(rcnet)/' openapi-spec.json
       - run: |
           ls -la
+      - run: find .
       - name: Generate rcnet collection
         run: |
           npx @apideck/portman -l ./gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -35,7 +35,7 @@ jobs:
       #  run: sed -i 's/(network-name)/(rcnet)/' openapi-spec.json
       - name: Generate rcnet collection
         run: |
-          npx @apideck/portman -l ${{ github.workspace }}/gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
+          npx @apideck/portman -l ./${{ github.workspace }}/gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
             -b https://rcnet.radixdlt.com
       - name: Setup localnet credentials
         uses: DamianReeves/write-file-action@v1.0

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -35,7 +35,7 @@ jobs:
       #  run: sed -i 's/(network-name)/(rcnet)/' openapi-spec.json
       - name: Generate rcnet collection
         run: |
-          npx @apideck/portman -l gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
+          npx @apideck/portman -l ${{ github.workspace }}/gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
             -b https://rcnet.radixdlt.com
       - name: Setup localnet credentials
         uses: DamianReeves/write-file-action@v1.0

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Generate and sync Postman's Gateway collection
         run: |
           npx @apideck/portman -l ./gateway/gateway-api-spec.yaml --syncPostman true --envFile .env -cliOptionsFile cliopts.json \
-            -b https://rcnet-gateway.radixdlt.com
+            --postmanUid 14449947-5d6c29d7-673a-482b-8fac-c2fa8f3adb4a -b https://rcnet-gateway.radixdlt.com
       #- name: Validate rcnet collection w/ newman
       #  run: newman run /tmp/collection.postman.json

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -12,42 +12,30 @@ jobs:
         with:
           access_token: ${{ github.token }}
   generate:
-    name: Sync postman collections
+    name: Sync Postman collections w/ spec from latest develop
     environment: Postman
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Postman credentials
+        uses: DamianReeves/write-file-action@v1.0
+        with:
+          path: .env
+          contents: POSTMAN_API_KEY=${{ secrets.POSTMAN_API_TOKEN }}
+          write-mode: append
       - name: Checkout gateway's openapi spec
         uses: actions/checkout@v2
         with:
           repository: radixdlt/radixdlt-network-gateway
           path: gateway
-      - name: Setup Postman credentials
+      - name: Setup Postman's Gateway config
         uses: DamianReeves/write-file-action@v1.0
         with:
-          path: .env-rcnet
-          contents: POSTMAN_API_KEY=${{ secrets.POSTMAN_API_TOKEN }}
+          path: cliopts.json
+          contents: {"postmanWorkspaceName":"Team Workspace","collectionName":"Gateway (develop)"}
           write-mode: append
-      #- name: Rename OpenApi spec name for rcnet
-      #  run: sed -i 's/(network-name)/(rcnet)/' openapi-spec.json
-      - run: |
-          cat .env-rcnet
-      - name: Generate rcnet collection
+      - name: Generate and sync Postman's Gateway collection
         run: |
-          npx @apideck/portman -l ./gateway/gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
-            --collectionName 'Gateway API (rcnet)' \
+          npx @apideck/portman -l ./gateway/gateway-api-spec.yaml --syncPostman true --envFile .env -cliOptionsFile cliopts.json \
             -b https://rcnet-gateway.radixdlt.com
-      - name: Setup localnet credentials
-        uses: DamianReeves/write-file-action@v1.0
-        with:
-          path: .env-local
-          contents: POSTMAN_API_KEY=${{ secrets.POSTMAN_API_TOKEN }}
-          write-mode: append
-      #- name: Rename OpenApi spec name for localnet
-      #  run: sed -i 's/(rcnet)/(localnet)/' openapi-spec.json
-      - name: Generate localnet collection
-        run: |
-          npx @apideck/portman -l ./gateway/gateway-api-spec.yaml --envFile .env-local --syncPostman true \
-            --collectionName 'Gateway API (localnet)' \
-            -b http://localhost:5308
-      - name: Validate rcnet collection w/ newman
-        run: newman run /tmp/collection.postman.json
+      #- name: Validate rcnet collection w/ newman
+      #  run: newman run /tmp/collection.postman.json

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -28,6 +28,7 @@ jobs:
           path: cliopts.json
           contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"Gateway API (develop)"}'
           write-mode: append
+      - run: ls
       - name: Generate and upload Postman's Gateway API collection
         run: |
           npx @apideck/portman -u https://raw.githubusercontent.com/radixdlt/radixdlt-network-gateway/develop/gateway-api-spec.yaml \
@@ -39,6 +40,7 @@ jobs:
           path: cliopts.json
           contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"Core API (develop)"}'
           write-mode: append
+      - run: ls
       - name: Generate and upload Postman's Core API collection
         run: |
           npx @apideck/portman \

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -43,7 +43,7 @@ jobs:
           repository: radixdlt/radixdlt
           path: core
       - name: Change OpenApi version in the Core API spec
-        run: sed -i 's/(3.0.0)/(3.1.0)/' core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml
+        run: sed -i 's/3.1.0/3.0.0/' core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml
       - name: Create Portman configuration for Core API
         uses: DamianReeves/write-file-action@v1.0
         with:

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -48,7 +48,8 @@ jobs:
           path: cliopts.json
           contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"Core API (develop)"}'
           write-mode: overwrite
-      - run: cat cliopts.json
+      - name: Change OpenApi version in the Core API spec
+        run: sed -i 's/(3.0.0)/(3.1.0)/' radixdlt/radixdlt/develop/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml
       - name: Generate and upload Postman's Core API collection
         run: |
           npx @apideck/portman -l radixdlt/radixdlt/develop/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml \

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -45,8 +45,9 @@ jobs:
       #- name: Rename OpenApi spec name for localnet
       #  run: sed -i 's/(rcnet)/(localnet)/' openapi-spec.json
       - name: Generate localnet collection
-        npx @apideck/portman -l ./gateway/gateway-api-spec.yaml --envFile .env-local --syncPostman true \
-          --collectionName 'Gateway API (localnet)' \
-          -b http://localhost:5308
+        run: |
+          npx @apideck/portman -l ./gateway/gateway-api-spec.yaml --envFile .env-local --syncPostman true \
+            --collectionName 'Gateway API (localnet)' \
+            -b http://localhost:5308
       - name: Validate rcnet collection w/ newman
         run: newman run /tmp/collection.postman.json

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -1,0 +1,47 @@
+name: Postman flow
+
+on: [push]
+
+jobs:
+  cancel_running_workflows:
+    name: Cancel running workflows
+    runs-on: ubuntu-20.04
+    steps:
+      - name: cancel running workflows
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+  generate:
+    name: Sync postman collections
+    environment: Postman
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout openapi spec
+        uses: actions/checkout@v2
+        with:
+          repository: Theoklitos/openapi-spec
+      - name: Setup rcnet credentials
+        uses: DamianReeves/write-file-action@v1.0
+        with:
+          path: .env-rcnet
+          contents: POSTMAN_API_KEY=${{ secrets.POSTMAN_API_TOKEN }}
+          write-mode: append
+      - name: Rename OpenApi spec name for rcnet
+        run: sed -i 's/(network-name)/(rcnet)/' openapi-spec.json
+      - name: Generate rcnet collection
+        run: |
+          npx @apideck/portman -l openapi-spec.json -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
+            -b https://rcnet.radixdlt.com
+      - name: Setup localnet credentials
+        uses: DamianReeves/write-file-action@v1.0
+        with:
+          path: .env-local
+          contents: POSTMAN_API_KEY=${{ secrets.POSTMAN_API_TOKEN }}
+          write-mode: append
+      - name: Rename OpenApi spec name for localnet
+        run: sed -i 's/(rcnet)/(localnet)/' openapi-spec.json
+      - name: Generate localnet collection
+        run: |
+          npx @apideck/portman -l openapi-spec.json -o /tmp/collection.postman.json --envFile .env-local --syncPostman true
+      - name: Validate rcnet collection w/ newman
+        run: newman run /tmp/collection.postman.json

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           path: cliopts.json
           contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"Core API (develop)"}'
-          write-mode: append
-      - run: ls
+          write-mode: overwrite
+      - run: cat cliopts.json
       - name: Generate and upload Postman's Core API collection
         run: |
           npx @apideck/portman \
@@ -52,7 +52,7 @@ jobs:
         with:
           path: cliopts.json
           contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"System API (develop)"}'
-          write-mode: append
+          write-mode: overwrite
       - name: Generate and upload Postman's System API collection
         run: |
           npx @apideck/portman \

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -1,6 +1,9 @@
-name: Postman flow
+name: sync-postman-collections
 
-on: [push]
+on:
+  push:
+    branches:
+      - develop
 
 jobs:
   cancel_running_workflows:
@@ -11,7 +14,7 @@ jobs:
         uses: styfle/cancel-workflow-action@0.8.0
         with:
           access_token: ${{ github.token }}
-  generate:
+  sync_postman_collections:
     name: Sync Postman collections w/ latest develop
     environment: Postman
     runs-on: ubuntu-20.04

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -1,9 +1,9 @@
 name: sync-postman-collections
 
-on: [push]
-#  push:
-#    branches:
-#      - develop
+on:
+  push:
+    branches:
+      - develop
 
 jobs:
   cancel_running_workflows:

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -31,7 +31,7 @@ jobs:
         uses: DamianReeves/write-file-action@v1.0
         with:
           path: cliopts.json
-          contents: {"postmanWorkspaceName":"Team Workspace","collectionName":"Gateway (develop)"}
+          contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"Gateway (develop)"}'
           write-mode: append
       - name: Generate and sync Postman's Gateway collection
         run: |

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
   generate:
-    name: Sync Postman collections w/ spec from latest develop
+    name: Sync Postman collections w/ latest develop
     environment: Postman
     runs-on: ubuntu-20.04
     steps:
@@ -22,24 +22,38 @@ jobs:
           path: .env
           contents: POSTMAN_API_KEY=${{ secrets.POSTMAN_API_TOKEN }}
           write-mode: append
-      - name: Checkout gateway's openapi spec
-        uses: actions/checkout@v2
-        with:
-          repository: radixdlt/radixdlt-network-gateway
-          path: gateway
-      - name: Setup Postman's Gateway config
+      - name: Create Portman configuration for Gateway API
         uses: DamianReeves/write-file-action@v1.0
         with:
           path: cliopts.json
-          contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"Gateway (develop)"}'
+          contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"Gateway API (develop)"}'
           write-mode: append
-      - run: |
-          ls
-      - run: |
-          cat cliopts.json
-      - name: Generate and sync Postman's Gateway collection
+      - name: Generate and upload Postman's Gateway API collection
         run: |
-          npx @apideck/portman -l ./gateway/gateway-api-spec.yaml --syncPostman true --envFile .env --cliOptionsFile cliopts.json \
-            --postmanUid 14449947-5d6c29d7-673a-482b-8fac-c2fa8f3adb4a -b https://rcnet-gateway.radixdlt.com
-      #- name: Validate rcnet collection w/ newman
-      #  run: newman run /tmp/collection.postman.json
+          npx @apideck/portman -u https://raw.githubusercontent.com/radixdlt/radixdlt-network-gateway/develop/gateway-api-spec.yaml \
+            --postmanUid 14449947-5d6c29d7-673a-482b-8fac-c2fa8f3adb4a \
+            --syncPostman true --envFile .env --cliOptionsFile cliopts.json
+      - name: Create Portman configuration for Core API
+        uses: DamianReeves/write-file-action@v1.0
+        with:
+          path: cliopts.json
+          contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"Core API (develop)"}'
+          write-mode: append
+      - name: Generate and upload Postman's Core API collection
+        run: |
+          npx @apideck/portman \
+            -u https://raw.githubusercontent.com/radixdlt/radixdlt/develop/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml \
+            --postmanUid 14449947-fb9a194f-6341-41d7-a826-8c701f0fbf57 \
+            --syncPostman true --envFile .env --cliOptionsFile cliopts.json
+      - name: Create Portman configuration for Core API
+        uses: DamianReeves/write-file-action@v1.0
+        with:
+          path: cliopts.json
+          contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"System API (develop)"}'
+          write-mode: append
+      - name: Generate and upload Postman's System API collection
+        run: |
+          npx @apideck/portman \
+            -u https://raw.githubusercontent.com/radixdlt/radixdlt/develop/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/system/api.yaml \
+            --postmanUid 14449947-cbede7fb-7361-4d91-becc-e1e10e0b2454 \
+            --syncPostman true --envFile .env --cliOptionsFile cliopts.json

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -1,9 +1,9 @@
 name: sync-postman-collections
 
-on:
-  push:
-    branches:
-      - develop
+on: [push]
+#  push:
+#    branches:
+#      - develop
 
 jobs:
   cancel_running_workflows:
@@ -14,8 +14,8 @@ jobs:
         uses: styfle/cancel-workflow-action@0.8.0
         with:
           access_token: ${{ github.token }}
-  sync_postman_collections:
-    name: Sync Postman collections w/ latest develop
+  sync_core_collection:
+    name: Sync Postman Core collection w/ latest develop
     environment: Postman
     runs-on: ubuntu-20.04
     steps:
@@ -24,20 +24,8 @@ jobs:
         with:
           path: .env
           contents: POSTMAN_API_KEY=${{ secrets.POSTMAN_API_TOKEN }}
-          write-mode: append
-      - name: Create Portman configuration for Gateway API
-        uses: DamianReeves/write-file-action@v1.0
-        with:
-          path: cliopts.json
-          contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"Gateway API (develop)"}'
-          write-mode: append
-      - run: ls
-      - name: Generate and upload Postman's Gateway API collection
-        run: |
-          npx @apideck/portman -u https://raw.githubusercontent.com/radixdlt/radixdlt-network-gateway/develop/gateway-api-spec.yaml \
-            --postmanUid 14449947-5d6c29d7-673a-482b-8fac-c2fa8f3adb4a \
-            --syncPostman true --envFile .env --cliOptionsFile cliopts.json
-      - name: Checkout core
+          write-mode: overwrite
+      - name: Checkout core repo
         uses: actions/checkout@v2
         with:
           repository: radixdlt/radixdlt
@@ -48,21 +36,38 @@ jobs:
         uses: DamianReeves/write-file-action@v1.0
         with:
           path: cliopts.json
-          contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"Core API (develop)"}'
+          contents: '{"postmanWorkspaceName":"Team Workspace"}'
           write-mode: overwrite
-      - name: Generate and upload Postman's Core API collection
+      - name: Replace hardcoded values with variables
+        run: |
+          sed -i 's/mainnet/"{{network}}"/g' core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml
+      - name: Update Postman's Core API collection from the spec
         run: |
           npx @apideck/portman -l core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml \
             --postmanUid 14449947-fb9a194f-6341-41d7-a826-8c701f0fbf57 \
             --syncPostman true --envFile .env --cliOptionsFile cliopts.json
-      - name: Create Portman configuration for Core API
-        uses: DamianReeves/write-file-action@v1.0
-        with:
-          path: cliopts.json
-          contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"System API (develop)"}'
-          write-mode: overwrite
-      - name: Generate and upload Postman's System API collection
+      - name: Download the collection
         run: |
-          npx @apideck/portman -l core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/system/api.yaml \
-            --postmanUid 14449947-cbede7fb-7361-4d91-becc-e1e10e0b2454 \
-            --syncPostman true --envFile .env --cliOptionsFile cliopts.json
+          curl -X GET -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" https://api.getpostman.com/collections/14449947-fb9a194f-6341-41d7-a826-8c701f0fbf57 > tmp.core.collection.json
+      - name: Add a timestamp to the name
+        run: |
+          sed -i 's/"name":".*","description":"This API/"name":"Core API (develop) ${{steps.date.outputs.date}} UTC","description":"This API/' tmp.core.collection.json
+      - name: Change the baseUrl variable name
+        run: |
+          sed -i 's/{{baseUrl}}/{{coreBaseUrl}}/g' tmp.core.collection.json
+      - name: Update the collection
+        run: |
+          curl -X PUT -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" -H "Content-Type: application/json" \
+             https://api.getpostman.com/collections/14449947-fb9a194f-6341-41d7-a826-8c701f0fbf57 --data "@tmp.core.collection.json"
+
+#      - name: Create Portman configuration for System API
+#        uses: DamianReeves/write-file-action@v1.0
+#        with:
+#          path: cliopts.json
+#          contents: '{"postmanWorkspaceName":"Team Workspace"}'
+#          write-mode: overwrite
+#      - name: Generate and upload Postman's System API collection
+#        run: |
+#          npx @apideck/portman -l core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/system/api.yaml \
+#            --postmanUid 14449947-cbede7fb-7361-4d91-becc-e1e10e0b2454 \
+#            --syncPostman true --envFile .env --cliOptionsFile cliopts.json

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -39,7 +39,7 @@ jobs:
           cat cliopts.json
       - name: Generate and sync Postman's Gateway collection
         run: |
-          npx @apideck/portman -l ./gateway/gateway-api-spec.yaml --syncPostman true --envFile .env -cliOptionsFile cliopts.json \
+          npx @apideck/portman -l ./gateway/gateway-api-spec.yaml --syncPostman true --envFile .env --cliOptionsFile cliopts.json \
             --postmanUid 14449947-5d6c29d7-673a-482b-8fac-c2fa8f3adb4a -b https://rcnet-gateway.radixdlt.com
       #- name: Validate rcnet collection w/ newman
       #  run: newman run /tmp/collection.postman.json

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -34,9 +34,6 @@ jobs:
           npx @apideck/portman -u https://raw.githubusercontent.com/radixdlt/radixdlt-network-gateway/develop/gateway-api-spec.yaml \
             --postmanUid 14449947-5d6c29d7-673a-482b-8fac-c2fa8f3adb4a \
             --syncPostman true --envFile .env --cliOptionsFile cliopts.json
-
-      # ===================================================== CORE ======================================
-
       - name: Checkout core
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -33,6 +33,10 @@ jobs:
           path: cliopts.json
           contents: '{"postmanWorkspaceName":"Team Workspace","collectionName":"Gateway (develop)"}'
           write-mode: append
+      - run: |
+          ls
+      - run: |
+          cat cliopts.json
       - name: Generate and sync Postman's Gateway collection
         run: |
           npx @apideck/portman -l ./gateway/gateway-api-spec.yaml --syncPostman true --envFile .env -cliOptionsFile cliopts.json \

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -30,7 +30,7 @@ jobs:
       #- name: Rename OpenApi spec name for rcnet
       #  run: sed -i 's/(network-name)/(rcnet)/' openapi-spec.json
       - run: |
-          ls
+          ls -la
       - name: Generate rcnet collection
         run: |
           npx @apideck/portman -l ./gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -72,7 +72,7 @@ jobs:
           curl -X GET -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" https://api.getpostman.com/collections/14449947-573cde3b-1504-4ba0-a865-ada778e08c74 > tmp.system.collection.json
       - name: Add a timestamp to the name
         run: |
-          sed -i 's/"name":".*","description":"This API/"name":"System API (develop) ${{steps.date.outputs.date}} UTC","description":"This API/' tmp.system.collection.json
+          sed -i 's/"name":".*","schema"/"name":"System API (develop) ${{steps.date.outputs.date}} UTC","schema"/' tmp.system.collection.json
       - name: Change the baseUrl variable name
         run: |
           sed -i 's/{{baseUrl}}/{{systembaseUrl}}/g' tmp.system.collection.json

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -27,11 +27,11 @@ jobs:
           path: .env-rcnet
           contents: POSTMAN_API_KEY=${{ secrets.POSTMAN_API_TOKEN }}
           write-mode: append
-      - name: Rename OpenApi spec name for rcnet
-        run: sed -i 's/(network-name)/(rcnet)/' openapi-spec.json
+      #- name: Rename OpenApi spec name for rcnet
+      #  run: sed -i 's/(network-name)/(rcnet)/' openapi-spec.json
       - name: Generate rcnet collection
         run: |
-          npx @apideck/portman -l openapi-spec.json -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
+          npx @apideck/portman -l gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
             -b https://rcnet.radixdlt.com
       - name: Setup localnet credentials
         uses: DamianReeves/write-file-action@v1.0
@@ -39,8 +39,8 @@ jobs:
           path: .env-local
           contents: POSTMAN_API_KEY=${{ secrets.POSTMAN_API_TOKEN }}
           write-mode: append
-      - name: Rename OpenApi spec name for localnet
-        run: sed -i 's/(rcnet)/(localnet)/' openapi-spec.json
+      #- name: Rename OpenApi spec name for localnet
+      #  run: sed -i 's/(rcnet)/(localnet)/' openapi-spec.json
       - name: Generate localnet collection
         run: |
           npx @apideck/portman -l openapi-spec.json -o /tmp/collection.postman.json --envFile .env-local --syncPostman true

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -1,9 +1,9 @@
 name: sync-postman-collections
 
-on:
-  push:
-    branches:
-      - develop
+on: [push]
+#  push:
+#    branches:
+#      - develop
 
 jobs:
   cancel_running_workflows:
@@ -47,8 +47,7 @@ jobs:
       - name: Update Postman's Core API collection from the spec
         run: |
           npx @apideck/portman -l core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml \
-            --postmanUid 14449947-f288f14a-5deb-4427-bde5-52c2f4c696de \
-            --syncPostman true --envFile .env --cliOptionsFile cliopts.json
+            --postmanUid 14449947-f288f14a-5deb-4427-bde5-52c2f4c696de --syncPostman true --envFile .env
       - name: Download the Core API collection
         run: |
           curl -X GET -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" https://api.getpostman.com/collections/14449947-f288f14a-5deb-4427-bde5-52c2f4c696de > tmp.core.collection.json
@@ -65,8 +64,7 @@ jobs:
       - name: Update Postman's System API collection from the spec
         run: |
           npx @apideck/portman -l core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/system/api.yaml \
-            --postmanUid 14449947-573cde3b-1504-4ba0-a865-ada778e08c74 \
-            --syncPostman true --envFile .env --cliOptionsFile cliopts.json
+            --postmanUid 14449947-573cde3b-1504-4ba0-a865-ada778e08c74 --syncPostman true --envFile .env
       - name: Download the System API collection
         run: |
           curl -X GET -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" https://api.getpostman.com/collections/14449947-573cde3b-1504-4ba0-a865-ada778e08c74 > tmp.system.collection.json

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -75,7 +75,7 @@ jobs:
           sed -i 's/"name":".*","schema"/"name":"System API (develop) ${{steps.date.outputs.date}} UTC","schema"/' tmp.system.collection.json
       - name: Change the baseUrl variable name
         run: |
-          sed -i 's/{{baseUrl}}/{{systembaseUrl}}/g' tmp.system.collection.json
+          sed -i 's/{{baseUrl}}/{{systemBaseUrl}}/g' tmp.system.collection.json
       - name: Update the System API collection
         run: |
           curl -X PUT -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" -H "Content-Type: application/json" \

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -34,6 +34,14 @@ jobs:
           npx @apideck/portman -u https://raw.githubusercontent.com/radixdlt/radixdlt-network-gateway/develop/gateway-api-spec.yaml \
             --postmanUid 14449947-5d6c29d7-673a-482b-8fac-c2fa8f3adb4a \
             --syncPostman true --envFile .env --cliOptionsFile cliopts.json
+
+      # ===================================================== CORE ======================================
+
+      - name: Checkout core
+        uses: actions/checkout@v2
+        with:
+          repository: radixdlt/radixdlt
+          path: core
       - name: Create Portman configuration for Core API
         uses: DamianReeves/write-file-action@v1.0
         with:
@@ -43,8 +51,7 @@ jobs:
       - run: cat cliopts.json
       - name: Generate and upload Postman's Core API collection
         run: |
-          npx @apideck/portman \
-            -u https://raw.githubusercontent.com/radixdlt/radixdlt/develop/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml \
+          npx @apideck/portman -l radixdlt/radixdlt/develop/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml \
             --postmanUid 14449947-fb9a194f-6341-41d7-a826-8c701f0fbf57 \
             --syncPostman true --envFile .env --cliOptionsFile cliopts.json
       - name: Create Portman configuration for Core API
@@ -55,7 +62,6 @@ jobs:
           write-mode: overwrite
       - name: Generate and upload Postman's System API collection
         run: |
-          npx @apideck/portman \
-            -u https://raw.githubusercontent.com/radixdlt/radixdlt/develop/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/system/api.yaml \
+          npx @apideck/portman -l radixdlt/radixdlt/develop/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/system/api.yaml \
             --postmanUid 14449947-cbede7fb-7361-4d91-becc-e1e10e0b2454 \
             --syncPostman true --envFile .env --cliOptionsFile cliopts.json

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -19,6 +19,9 @@ jobs:
     environment: Postman
     runs-on: ubuntu-20.04
     steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%b %d, %H:%M')"
       - name: Setup Postman credentials
         uses: DamianReeves/write-file-action@v1.0
         with:
@@ -46,7 +49,7 @@ jobs:
           npx @apideck/portman -l core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml \
             --postmanUid 14449947-f288f14a-5deb-4427-bde5-52c2f4c696de \
             --syncPostman true --envFile .env --cliOptionsFile cliopts.json
-      - name: Download the collection
+      - name: Download the Core API collection
         run: |
           curl -X GET -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" https://api.getpostman.com/collections/14449947-f288f14a-5deb-4427-bde5-52c2f4c696de > tmp.core.collection.json
       - name: Add a timestamp to the name
@@ -55,19 +58,25 @@ jobs:
       - name: Change the baseUrl variable name
         run: |
           sed -i 's/{{baseUrl}}/{{coreBaseUrl}}/g' tmp.core.collection.json
-      - name: Update the collection
+      - name: Update the Core API collection
         run: |
           curl -X PUT -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" -H "Content-Type: application/json" \
              https://api.getpostman.com/collections/14449947-f288f14a-5deb-4427-bde5-52c2f4c696de --data "@tmp.core.collection.json"
-
-#      - name: Create Portman configuration for System API
-#        uses: DamianReeves/write-file-action@v1.0
-#        with:
-#          path: cliopts.json
-#          contents: '{"postmanWorkspaceName":"Team Workspace"}'
-#          write-mode: overwrite
-#      - name: Generate and upload Postman's System API collection
-#        run: |
-#          npx @apideck/portman -l core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/system/api.yaml \
-#            --postmanUid 14449947-cbede7fb-7361-4d91-becc-e1e10e0b2454 \
-#            --syncPostman true --envFile .env --cliOptionsFile cliopts.json
+      - name: Update Postman's System API collection from the spec
+        run: |
+          npx @apideck/portman -l core/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/system/api.yaml \
+            --postmanUid 14449947-573cde3b-1504-4ba0-a865-ada778e08c74 \
+            --syncPostman true --envFile .env --cliOptionsFile cliopts.json
+      - name: Download the System API collection
+        run: |
+          curl -X GET -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" https://api.getpostman.com/collections/14449947-573cde3b-1504-4ba0-a865-ada778e08c74 > tmp.system.collection.json
+      - name: Add a timestamp to the name
+        run: |
+          sed -i 's/"name":".*","description":"This API/"name":"System API (develop) ${{steps.date.outputs.date}} UTC","description":"This API/' tmp.system.collection.json
+      - name: Change the baseUrl variable name
+        run: |
+          sed -i 's/{{baseUrl}}/{{systembaseUrl}}/g' tmp.system.collection.json
+      - name: Update the System API collection
+        run: |
+          curl -X PUT -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" -H "Content-Type: application/json" \
+             https://api.getpostman.com/collections/14449947-573cde3b-1504-4ba0-a865-ada778e08c74 --data "@tmp.system.collection.json"

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Generate rcnet collection
         run: |
           npx @apideck/portman -l ./gateway/gateway-api-spec.yaml -o /tmp/collection.postman.json --envFile .env-rcnet --syncPostman true \
+            --collectionName 'Gateway API (rcnet)' \
             -b https://rcnet-gateway.radixdlt.com
       - name: Setup localnet credentials
         uses: DamianReeves/write-file-action@v1.0
@@ -44,7 +45,8 @@ jobs:
       #- name: Rename OpenApi spec name for localnet
       #  run: sed -i 's/(rcnet)/(localnet)/' openapi-spec.json
       - name: Generate localnet collection
-        run: |
-          npx @apideck/portman -l openapi-spec.json -o /tmp/collection.postman.json --envFile .env-local --syncPostman true
+        npx @apideck/portman -l ./gateway/gateway-api-spec.yaml --envFile .env-local --syncPostman true \
+          --collectionName 'Gateway API (localnet)' \
+          -b http://localhost:5308
       - name: Validate rcnet collection w/ newman
         run: newman run /tmp/collection.postman.json

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   version: 1.0.0
   title: Radix Core API
@@ -66,7 +66,7 @@ info:
     See https://openapi-generator.tech/ for more details.
 
     The OpenAPI generator only supports openapi version 3.0.0 at present, but you can
-    change 3.1.0 to 3.0.0 in the first line of the spec without affecting generation.
+    change 3.0.0 to 3.0.0 in the first line of the spec without affecting generation.
 
     # Data API Flow
 
@@ -481,7 +481,7 @@ tags:
                 },
                 "substate": {
                   "substate_identifier": {
-                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b8115371c05c6565f9fb6a4900000000"
+                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b81153.0.05c6565f9fb6a4900000000"
                   },
                   "substate_operation": "BOOTUP"
                 },
@@ -504,7 +504,7 @@ tags:
                 },
                 "substate": {
                   "substate_identifier": {
-                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b8115371c05c6565f9fb6a4900000000"
+                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b81153.0.05c6565f9fb6a4900000000"
                   },
                   "substate_operation": "SHUTDOWN"
                 },
@@ -526,7 +526,7 @@ tags:
                 },
                 "substate": {
                   "substate_identifier": {
-                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b8115371c05c6565f9fb6a4900000001"
+                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b81153.0.05c6565f9fb6a4900000001"
                   },
                   "substate_operation": "BOOTUP"
                 },
@@ -548,7 +548,7 @@ tags:
                 },
                 "substate": {
                   "substate_identifier": {
-                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b8115371c05c6565f9fb6a4900000002"
+                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b81153.0.05c6565f9fb6a4900000002"
                   },
                   "substate_operation": "BOOTUP"
                 },
@@ -3584,4 +3584,4 @@ components:
         data_object:
           round: 0
           type: RoundData
-          timestamp: 1627330381600
+          timestamp: 16273303.0.00

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/api/core/api.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   version: 1.0.0
   title: Radix Core API
@@ -66,7 +66,7 @@ info:
     See https://openapi-generator.tech/ for more details.
 
     The OpenAPI generator only supports openapi version 3.0.0 at present, but you can
-    change 3.0.0 to 3.0.0 in the first line of the spec without affecting generation.
+    change 3.1.0 to 3.0.0 in the first line of the spec without affecting generation.
 
     # Data API Flow
 
@@ -481,7 +481,7 @@ tags:
                 },
                 "substate": {
                   "substate_identifier": {
-                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b81153.0.05c6565f9fb6a4900000000"
+                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b8115371c05c6565f9fb6a4900000000"
                   },
                   "substate_operation": "BOOTUP"
                 },
@@ -504,7 +504,7 @@ tags:
                 },
                 "substate": {
                   "substate_identifier": {
-                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b81153.0.05c6565f9fb6a4900000000"
+                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b8115371c05c6565f9fb6a4900000000"
                   },
                   "substate_operation": "SHUTDOWN"
                 },
@@ -526,7 +526,7 @@ tags:
                 },
                 "substate": {
                   "substate_identifier": {
-                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b81153.0.05c6565f9fb6a4900000001"
+                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b8115371c05c6565f9fb6a4900000001"
                   },
                   "substate_operation": "BOOTUP"
                 },
@@ -548,7 +548,7 @@ tags:
                 },
                 "substate": {
                   "substate_identifier": {
-                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b81153.0.05c6565f9fb6a4900000002"
+                    "identifier": "65f61dba3ed40a438c4694e8947f73530c1c6ca6b8115371c05c6565f9fb6a4900000002"
                   },
                   "substate_operation": "BOOTUP"
                 },
@@ -3584,4 +3584,4 @@ components:
         data_object:
           round: 0
           type: RoundData
-          timestamp: 16273303.0.00
+          timestamp: 1627330381600


### PR DESCRIPTION
Adds [a job](https://github.com/radixdlt/radixdlt/runs/4854242091?check_suite_focus=true) which updates the Core & System Postman collections, from the spec in the latest `develop`. Example:
![image](https://user-images.githubusercontent.com/3509654/149955622-0bdcc4f3-6cc2-4056-8c2a-4ad41a768ef7.png)
![image](https://user-images.githubusercontent.com/3509654/149956003-e4bca398-0913-4f42-916c-0ec89b0e06ed.png)

Links to the collections above:
* [Core API](https://radixdlt.postman.co/workspace/Team-Workspace~7486b08f-e45f-4aa9-829c-159113202071/collection/14449947-f288f14a-5deb-4427-bde5-52c2f4c696de?ctx=documentation)
* [System API](https://radixdlt.postman.co/workspace/Team-Workspace~7486b08f-e45f-4aa9-829c-159113202071/collection/14449947-573cde3b-1504-4ba0-a865-ada778e08c74?ctx=documentation)

You can find these in our Team Workspace in Postman.