### PR TITLE
Suppress unnecessary warnings and fix deb4docker build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,27 +173,26 @@ allprojects {
         maven { url 'https://jitpack.io' }
     }
 
-    gradle.projectsEvaluated {
-        tasks.withType(JavaCompile) {
-            options.release = 17
-            options.encoding = "UTF-8"
-            options.compilerArgs << "--enable-preview"
-            options.compilerArgs << "-Xlint:all"
+    tasks.withType(JavaCompile) {
+        options.release = 17
+        options.encoding = "UTF-8"
+        options.compilerArgs << "--enable-preview"
+        options.compilerArgs << "-Xlint:all"
 
-            //TODO: uncomment once warnings will be cleared
-            //options.compilerArgs << "-Werror"
+        //TODO: uncomment once warnings will be cleared
+        //options.compilerArgs << "-Werror"
 
-            options.compilerArgs << "-Xlint:-processing"    // Not really a useful warning
-            options.compilerArgs << "-Xlint:-serial"        //TODO: fix code to remove these warnings
-            options.compilerArgs << "-Xlint:-deprecation"   //TODO: fix code to remove these warnings
-            options.compilerArgs << "-Xlint:-unchecked"     //TODO: fix code to remove these warnings
-            options.compilerArgs << "-Xlint:-rawtypes"      //TODO: fix code to remove these warnings
-        }
+        options.compilerArgs << "-Xlint:-processing"    // Not really a useful warning
+        options.compilerArgs << "-Xlint:-serial"        //TODO: fix code to remove these warnings
+        options.compilerArgs << "-Xlint:-deprecation"   //TODO: fix code to remove these warnings
+        options.compilerArgs << "-Xlint:-unchecked"     //TODO: fix code to remove these warnings
+        options.compilerArgs << "-Xlint:-rawtypes"      //TODO: fix code to remove these warnings
+        options.compilerArgs << "-Xlint:-preview"
+    }
 
-        tasks.withType(Test) {
-            systemProperty "file.encoding", "UTF-8"
-            jvmArgs("--enable-preview")
-        }
+    tasks.withType(Test) {
+        systemProperty "file.encoding", "UTF-8"
+        jvmArgs("--enable-preview")
     }
 }
 

--- a/radixdlt-core/Makefile
+++ b/radixdlt-core/Makefile
@@ -8,7 +8,7 @@ all:
 
 .PHONY: build
 build-core:
-	cd radixdlt && ../../gradlew deb4docker
+	cd .. && ./gradlew deb4docker
 
 .PHONY: package
 package: build-core


### PR DESCRIPTION
- Suppress compilation warnings related to preview features
- Make deb4docker build invoke gradle from project root instead of subproject to ensure proper build configuration