### PR TITLE
Rollback copyright template and fix headers

### DIFF
--- a/licence-header.txt
+++ b/licence-header.txt
@@ -1,4 +1,4 @@
-/* Copyright $YEAR Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
  *
  * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:

--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/steady_state/deterministic/full_function/ApiTest.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/integration/steady_state/deterministic/full_function/ApiTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2022 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
  *
  * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/utils/LedgerHeaderMock.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/utils/LedgerHeaderMock.java
@@ -1,4 +1,4 @@
-/* Copyright 2022 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
  *
  * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
  * file except in compliance with the License. You may obtain a copy of the License at:


### PR DESCRIPTION
- Replace $YEAR with 2021
- Fix files which received 2022 in copyright header.