### PR TITLE
Try to connect to more than one known peer URI

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerManager.java
@@ -70,6 +70,7 @@ import static com.radixdlt.network.messaging.MessagingErrors.SELF_CONNECTION_ATT
 import static com.radixdlt.utils.functional.Tuple.unitResult;
 import static java.util.function.Predicate.not;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
@@ -106,6 +107,8 @@ import org.apache.logging.log4j.Logger;
 /** Manages active connections to other peers. */
 public final class PeerManager {
   private static final Logger log = LogManager.getLogger();
+
+  private static final int MAX_URIS_TO_TRY_FOR_SINGLE_CONNECT_TRIGGER = 5;
 
   private final NodeId self;
   private final P2PConfig config;
@@ -154,14 +157,25 @@ public final class PeerManager {
     if (maybeActiveChannel.isPresent()) {
       return CompletableFuture.completedFuture(maybeActiveChannel.get());
     } else {
-      final var maybeAddress = this.addressBook.get().findBestKnownAddressById(nodeId);
+      final var addresses = this.addressBook.get().bestKnownAddressesById(nodeId);
+      return tryConnectWithRetries(addresses, MAX_URIS_TO_TRY_FOR_SINGLE_CONNECT_TRIGGER);
+    }
+  }
 
-      if (maybeAddress.isPresent()) {
-        return connect(maybeAddress.get());
-      } else {
-        return CompletableFuture.failedFuture(
-            new RuntimeException("Unknown peer " + nodeAddress(nodeId)));
-      }
+  private CompletableFuture<PeerChannel> tryConnectWithRetries(
+      ImmutableList<RadixNodeUri> remainingAddresses, int triesLeft) {
+    if (remainingAddresses.isEmpty() || triesLeft <= 0) {
+      return CompletableFuture.failedFuture(
+          new RuntimeException("No valid address available for peer"));
+    } else {
+      final var nextAddr = remainingAddresses.get(0);
+      final var channelFuture = connect(nextAddr);
+      return channelFuture.exceptionallyCompose(
+          ex -> {
+            final var newRemainingAddresses =
+                remainingAddresses.stream().skip(1).collect(ImmutableList.toImmutableList());
+            return tryConnectWithRetries(newRemainingAddresses, triesLeft - 1);
+          });
     }
   }
 

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PeerManager.java
@@ -89,6 +89,7 @@ import com.radixdlt.network.p2p.addressbook.AddressBook;
 import com.radixdlt.network.p2p.addressbook.AddressBookEntry;
 import com.radixdlt.network.p2p.transport.PeerChannel;
 import com.radixdlt.networks.Addressing;
+import com.radixdlt.utils.Lists;
 import com.radixdlt.utils.functional.Result;
 import com.radixdlt.utils.functional.Tuple.Unit;
 import io.reactivex.rxjava3.core.Observable;
@@ -171,11 +172,7 @@ public final class PeerManager {
       final var nextAddr = remainingAddresses.get(0);
       final var channelFuture = connect(nextAddr);
       return channelFuture.exceptionallyCompose(
-          ex -> {
-            final var newRemainingAddresses =
-                remainingAddresses.stream().skip(1).collect(ImmutableList.toImmutableList());
-            return tryConnectWithRetries(newRemainingAddresses, triesLeft - 1);
-          });
+          ex -> tryConnectWithRetries(Lists.tail(remainingAddresses), triesLeft - 1));
     }
   }
 

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBook.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/addressbook/AddressBook.java
@@ -66,6 +66,7 @@ package com.radixdlt.network.p2p.addressbook;
 
 import static java.util.function.Predicate.not;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
@@ -212,7 +213,7 @@ public final class AddressBook {
     return Optional.ofNullable(this.knownPeers.get(nodeId));
   }
 
-  public Optional<RadixNodeUri> findBestKnownAddressById(NodeId nodeId) {
+  public ImmutableList<RadixNodeUri> bestKnownAddressesById(NodeId nodeId) {
     synchronized (lock) {
       return Optional.ofNullable(this.knownPeers.get(nodeId)).stream()
           .filter(not(AddressBookEntry::isBanned))
@@ -220,7 +221,7 @@ public final class AddressBook {
           .filter(not(PeerAddressEntry::blacklisted))
           .sorted(addressEntryComparator)
           .map(AddressBookEntry.PeerAddressEntry::getUri)
-          .findFirst();
+          .collect(ImmutableList.toImmutableList());
     }
   }
 

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/AddressBookTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/addressbook/AddressBookTest.java
@@ -117,23 +117,23 @@ public final class AddressBookTest {
     sut.addUncheckedPeers(ImmutableSet.of(addr1, addr2, addr3, addr4));
 
     sut.addOrUpdatePeerWithSuccessfulConnection(addr1);
-    final var bestAddr = sut.findBestKnownAddressById(peerId).orElseThrow();
+    final var bestAddr = sut.bestKnownAddressesById(peerId).get(0);
     assertEquals(addr1, bestAddr);
 
     sut.addOrUpdatePeerWithSuccessfulConnection(addr2);
-    final var bestAddr2 = sut.findBestKnownAddressById(peerId).orElseThrow();
+    final var bestAddr2 = sut.bestKnownAddressesById(peerId).get(0);
     assertTrue(bestAddr2 == addr1 || bestAddr2 == addr2);
 
     sut.addOrUpdatePeerWithFailedConnection(addr1);
-    final var bestAddr3 = sut.findBestKnownAddressById(peerId).orElseThrow();
+    final var bestAddr3 = sut.bestKnownAddressesById(peerId).get(0);
     assertEquals(addr2, bestAddr3);
 
     sut.addOrUpdatePeerWithFailedConnection(addr2);
-    final var bestAddr4 = sut.findBestKnownAddressById(peerId).orElseThrow();
+    final var bestAddr4 = sut.bestKnownAddressesById(peerId).get(0);
     assertTrue(bestAddr4 == addr3 || bestAddr4 == addr4);
 
     sut.addOrUpdatePeerWithSuccessfulConnection(addr4);
-    final var bestAddr5 = sut.findBestKnownAddressById(peerId).orElseThrow();
+    final var bestAddr5 = sut.bestKnownAddressesById(peerId).get(0);
     assertEquals(addr4, bestAddr5);
   }
 
@@ -153,12 +153,12 @@ public final class AddressBookTest {
 
     sut.addUncheckedPeers(ImmutableSet.of(addr1, addr2, addr3));
 
-    var prevPrevBestAddr = sut.findBestKnownAddressById(peerId).orElseThrow();
+    var prevPrevBestAddr = sut.bestKnownAddressesById(peerId).get(0);
     sut.addOrUpdatePeerWithFailedConnection(prevPrevBestAddr);
-    var prevBestAddr = sut.findBestKnownAddressById(peerId).orElseThrow();
+    var prevBestAddr = sut.bestKnownAddressesById(peerId).get(0);
     for (int i = 0; i < 50; i++) {
       sut.addOrUpdatePeerWithFailedConnection(prevBestAddr);
-      final var currBestAddr = sut.findBestKnownAddressById(peerId).orElseThrow();
+      final var currBestAddr = sut.bestKnownAddressesById(peerId).get(0);
       assertNotEquals(prevBestAddr, currBestAddr);
       assertNotEquals(prevPrevBestAddr, prevBestAddr);
       prevPrevBestAddr = prevBestAddr;

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/test/MockP2PNetwork.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/network/p2p/test/MockP2PNetwork.java
@@ -97,17 +97,15 @@ final class MockP2PNetwork {
 
   void createChannel(int clientPeerIndex, RadixNodeUri serverPeerUri) {
     final var clientPeer = nodes.get(clientPeerIndex);
-    final var serverPeer =
+    final var serverPeerOpt =
         nodes.stream()
             .filter(
                 p ->
                     p.uri.getHost().equals(serverPeerUri.getHost())
                         && p.uri.getPort() == serverPeerUri.getPort())
-            .findAny()
-            .get();
+            .findAny();
 
     final var clientSocketChannel = mock(SocketChannel.class);
-    final var serverSocketChannel = mock(SocketChannel.class);
 
     final var clientChannel =
         new PeerChannel(
@@ -122,6 +120,16 @@ final class MockP2PNetwork {
             Optional.of(serverPeerUri),
             clientSocketChannel,
             Optional.empty());
+
+    if (serverPeerOpt.isEmpty()) {
+      clientChannel.channelActive(null /* unused */);
+      clientChannel.channelInactive(null /* unused */);
+      return;
+    }
+
+    final var serverPeer = serverPeerOpt.get();
+
+    final var serverSocketChannel = mock(SocketChannel.class);
 
     final var serverChannel =
         new PeerChannel(

--- a/radixdlt-java-common/src/main/java/com/radixdlt/utils/Lists.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/utils/Lists.java
@@ -1,0 +1,73 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
+package com.radixdlt.utils;
+
+import com.google.common.collect.ImmutableList;
+
+public final class Lists {
+  public static <T> ImmutableList<T> tail(ImmutableList<T> list) {
+    return list.stream().skip(1).collect(ImmutableList.toImmutableList());
+  }
+}


### PR DESCRIPTION
Previously, when the network layer attempted to initialize a peer connection, only a single URI was tried (even if more were known). This changes it so that up to 5 (const value) is tried.
This will reduce the time needed to connect to a peer that has switched an IP address.