### PR TITLE
Forward origin peer to MempoolAddSuccess event

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/RadixEngineStateComputer.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/RadixEngineStateComputer.java
@@ -226,7 +226,7 @@ public final class RadixEngineStateComputer implements StateComputer {
         .forEach(
             txn -> {
               try {
-                addToMempool(txn);
+                addToMempool(txn, origin);
               } catch (MempoolRejectedException ignored) {
               }
             });

--- a/radixdlt-core/radixdlt/src/test/java/com/radixdlt/statecomputer/RadixEngineStateComputerTest.java
+++ b/radixdlt-core/radixdlt/src/test/java/com/radixdlt/statecomputer/RadixEngineStateComputerTest.java
@@ -67,7 +67,9 @@ package com.radixdlt.statecomputer;
 import static com.radixdlt.atom.TxAction.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -115,6 +117,7 @@ import com.radixdlt.ledger.LedgerUpdate;
 import com.radixdlt.ledger.SimpleLedgerAccumulatorAndVerifier;
 import com.radixdlt.ledger.StateComputerLedger.StateComputerResult;
 import com.radixdlt.ledger.VerifiedTxnsAndProof;
+import com.radixdlt.mempool.MempoolAdd;
 import com.radixdlt.mempool.MempoolAddSuccess;
 import com.radixdlt.mempool.MempoolConfig;
 import com.radixdlt.mempool.MempoolRelayTrigger;
@@ -153,6 +156,8 @@ public class RadixEngineStateComputerTest {
   @Inject private RERules rules;
 
   @Inject private ProposerElection proposerElection;
+
+  @Inject private EventDispatcher<MempoolAddSuccess> mempoolAddSuccessEventDispatcher;
 
   private Serialization serialization = DefaultSerialization.getInstance();
   private InMemoryEngineStore<LedgerAndBFTProof> engineStore;
@@ -484,5 +489,20 @@ public class RadixEngineStateComputerTest {
     // Assert
     assertThatThrownBy(() -> sut.commit(commandsAndProof, null))
         .isInstanceOf(ByzantineQuorumException.class);
+  }
+
+  @Test
+  public void add_to_mempool__should_forward_the_origin_to_the_event() throws TxBuilderException {
+    // Arrange
+    final var origin = BFTNode.random();
+    var txn = registerCommand(ECKeyPair.generateNew());
+
+    // Act
+    sut.addToMempool(MempoolAdd.create(txn), origin);
+
+    // Assert
+    verify(mempoolAddSuccessEventDispatcher)
+        .dispatch(
+            argThat(ev -> ev.getOrigin().orElseThrow().equals(origin) && ev.getTxn().equals(txn)));
   }
 }


### PR DESCRIPTION
Forward origin peer to MempoolAddSuccess event so that the tx is not relayed back
