### PR TITLE
Fix deadlock related to how the PendingChannelsManager completes the futures

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PendingOutboundChannelsManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PendingOutboundChannelsManager.java
@@ -107,6 +107,8 @@ public final class PendingOutboundChannelsManager {
     var existingChannelFutureOpt =
         Optional.ofNullable(this.pendingChannels.putIfAbsent(remoteNodeId, newChannelFuture));
 
+    // There was no existing channel future that has already been initialized for this node ID
+    //   so we init a new outbound connection
     if (existingChannelFutureOpt.isEmpty()) {
       this.peerOutboundBootstrap.initOutboundConnection(uri);
       this.timeoutEventDispatcher.dispatch(

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PendingOutboundChannelsManager.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/PendingOutboundChannelsManager.java
@@ -128,37 +128,43 @@ public final class PendingOutboundChannelsManager {
   }
 
   private void handlePeerConnected(PeerConnected peerConnected) {
+    final var channel = peerConnected.channel();
+    final Optional<CompletableFuture<PeerChannel>> channelFutureOpt;
     synchronized (lock) {
-      final var channel = peerConnected.channel();
-      final var maybeFuture = this.pendingChannels.remove(channel.getRemoteNodeId());
-      if (maybeFuture != null) {
-        maybeFuture.complete(channel);
-      }
+      channelFutureOpt =
+          Optional.ofNullable(this.pendingChannels.remove(channel.getRemoteNodeId()));
     }
+    channelFutureOpt.ifPresent(channelFuture -> channelFuture.complete(channel));
   }
 
   private void handlePeerHandshakeFailed(PeerHandshakeFailed peerHandshakeFailed) {
+    final Optional<CompletableFuture<PeerChannel>> channelFutureOpt;
     synchronized (lock) {
-      peerHandshakeFailed
-          .channel()
-          .getUri()
-          .map(RadixNodeUri::getNodeId)
-          .flatMap(nodeId -> Optional.ofNullable(this.pendingChannels.remove(nodeId)))
-          .ifPresent(
-              future -> future.completeExceptionally(new IOException("Peer connection failed")));
+      channelFutureOpt =
+          peerHandshakeFailed
+              .channel()
+              .getUri()
+              .map(RadixNodeUri::getNodeId)
+              .flatMap(nodeId -> Optional.ofNullable(this.pendingChannels.remove(nodeId)));
     }
+    channelFutureOpt.ifPresent(
+        channelFuture ->
+            channelFuture.completeExceptionally(new IOException("Peer connection failed")));
   }
 
   public EventProcessor<PeerOutboundConnectionTimeout>
       peerOutboundConnectionTimeoutEventProcessor() {
     return timeout -> {
+      final Optional<CompletableFuture<PeerChannel>> channelFutureOpt;
       synchronized (lock) {
-        final var maybeFuture = this.pendingChannels.remove(timeout.uri().getNodeId());
-        if (maybeFuture != null) {
-          maybeFuture.completeExceptionally(new IOException("Peer connection timeout"));
-          peerEventDispatcher.dispatch(new PeerConnectionTimeout(timeout.uri()));
-        }
+        channelFutureOpt =
+            Optional.ofNullable(this.pendingChannels.remove(timeout.uri().getNodeId()));
       }
+      channelFutureOpt.ifPresent(
+          channelFuture -> {
+            channelFuture.completeExceptionally(new IOException("Peer connection timeout"));
+            peerEventDispatcher.dispatch(new PeerConnectionTimeout(timeout.uri()));
+          });
     };
   }
 


### PR DESCRIPTION
The fix is to release the lock before calling `channelFuture.completeExceptionally`