### PR TITLE
Use dedicated hosts for the integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
       - name: integration tests
         run: ./gradlew integrationTest --refresh-dependencies
+        env:
+          JAVA_TOOL_OPTIONS: "-XX:ActiveProcessorCount=16"
   targeted-integration:
     name: Targeted integration tests
     runs-on: integration-tests
@@ -77,3 +79,5 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
       - name: targeted integration tests
         run: ./gradlew targetedIntegrationTest --refresh-dependencies
+        env:
+          JAVA_TOOL_OPTIONS: "-XX:ActiveProcessorCount=16"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - name: Unit tests and Sonar analisys
+      - name: Unit tests and Sonar analysis
         run: ./gradlew clean check jacocoTestReport sonarqube --stacktrace --refresh-dependencies -Dsonar.login=$SONAR_TOKEN
         env:
           # Needed to get some information about the pull request, if any
@@ -37,7 +37,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   integration:
     name: Steady state integration tests
-    runs-on: ubuntu-20.04
+    runs-on: integration-tests
     steps:
       - uses: actions/checkout@v2
         with:
@@ -58,7 +58,7 @@ jobs:
         run: ./gradlew integrationTest --refresh-dependencies
   targeted-integration:
     name: Targeted integration tests
-    runs-on: ubuntu-20.04
+    runs-on: integration-tests
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,6 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
       - name: integration tests
         run: ./gradlew integrationTest --refresh-dependencies
-        env:
-          JAVA_TOOL_OPTIONS: "-XX:ActiveProcessorCount=16"
   targeted-integration:
     name: Targeted integration tests
     runs-on: integration-tests
@@ -79,5 +77,3 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
       - name: targeted integration tests
         run: ./gradlew targetedIntegrationTest --refresh-dependencies
-        env:
-          JAVA_TOOL_OPTIONS: "-XX:ActiveProcessorCount=16"


### PR DESCRIPTION
The PR configures the integration jobs to use a dedicated runner.