### PR TITLE
Fix integration tests

### DIFF
--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/harness/MockedPeersViewModule.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/harness/MockedPeersViewModule.java
@@ -76,7 +76,8 @@ import com.radixdlt.network.p2p.PeersView;
 public class MockedPeersViewModule extends AbstractModule {
   private final ImmutableMap<ECPublicKey, ImmutableList<ECPublicKey>> peersByNodeOrNull;
 
-  public MockedPeersViewModule(ImmutableMap<ECPublicKey, ImmutableList<ECPublicKey>> peersByNodeOrNull) {
+  public MockedPeersViewModule(
+      ImmutableMap<ECPublicKey, ImmutableList<ECPublicKey>> peersByNodeOrNull) {
     this.peersByNodeOrNull = peersByNodeOrNull;
   }
 

--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/harness/MockedPeersViewModule.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/harness/MockedPeersViewModule.java
@@ -72,20 +72,19 @@ import com.radixdlt.consensus.bft.BFTNode;
 import com.radixdlt.consensus.bft.Self;
 import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.network.p2p.PeersView;
-import java.util.Objects;
 
 public class MockedPeersViewModule extends AbstractModule {
-  private final ImmutableMap<ECPublicKey, ImmutableList<ECPublicKey>> nodes;
+  private final ImmutableMap<ECPublicKey, ImmutableList<ECPublicKey>> peersByNodeOrNull;
 
-  public MockedPeersViewModule(ImmutableMap<ECPublicKey, ImmutableList<ECPublicKey>> nodes) {
-    this.nodes = Objects.requireNonNull(nodes);
+  public MockedPeersViewModule(ImmutableMap<ECPublicKey, ImmutableList<ECPublicKey>> peersByNodeOrNull) {
+    this.peersByNodeOrNull = peersByNodeOrNull;
   }
 
   @Provides
   public PeersView peersView(@Self BFTNode self, ImmutableList<BFTNode> allNodes) {
     final var peersForNode =
-        nodes.containsKey(self.getKey())
-            ? nodes // Use a specific set of peers for the given node, if defined
+        peersByNodeOrNull != null && peersByNodeOrNull.containsKey(self.getKey())
+            ? peersByNodeOrNull // Use a specific set of peers for the given node, if defined
                 .get(self.getKey())
                 .stream()
                 .map(BFTNode::create)

--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/harness/MockedPeersViewModule.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/harness/MockedPeersViewModule.java
@@ -92,8 +92,12 @@ public class MockedPeersViewModule extends AbstractModule {
                 .collect(ImmutableList.toImmutableList())
             : allNodes; // Else return all the nodes in the network
 
-    final var peersForNodeWithoutSelf = peersForNode.stream().filter(n -> !n.equals(self));
+    final var peersForNodeWithoutSelf =
+        peersForNode.stream()
+            .filter(n -> !n.equals(self))
+            .map(PeersView.PeerInfo::fromBftNode)
+            .collect(ImmutableList.toImmutableList());
 
-    return () -> peersForNodeWithoutSelf.map(PeersView.PeerInfo::fromBftNode);
+    return peersForNodeWithoutSelf::stream;
   }
 }

--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/harness/MockedPeersViewModule.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/harness/MockedPeersViewModule.java
@@ -76,6 +76,9 @@ import com.radixdlt.network.p2p.PeersView;
 public class MockedPeersViewModule extends AbstractModule {
   private final ImmutableMap<ECPublicKey, ImmutableList<ECPublicKey>> peersByNodeOrNull;
 
+  /**
+   * @param peersByNodeOrNull - If passed a null map, then each node is assumed to have each other node as a peer.
+   */
   public MockedPeersViewModule(
       ImmutableMap<ECPublicKey, ImmutableList<ECPublicKey>> peersByNodeOrNull) {
     this.peersByNodeOrNull = peersByNodeOrNull;
@@ -98,6 +101,8 @@ public class MockedPeersViewModule extends AbstractModule {
             .map(PeersView.PeerInfo::fromBftNode)
             .collect(ImmutableList.toImmutableList());
 
+    // PeersView is a functional interface, so we're actually returning an implementation of PeersView.peers
+    // To avoid exceptions from multiple iterations of a stream, each call to PeersView.peers returns a new stream
     return peersForNodeWithoutSelf::stream;
   }
 }

--- a/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/harness/MockedPeersViewModule.java
+++ b/radixdlt-core/radixdlt/src/integration/java/com/radixdlt/harness/MockedPeersViewModule.java
@@ -74,21 +74,22 @@ import com.radixdlt.crypto.ECPublicKey;
 import com.radixdlt.network.p2p.PeersView;
 
 public class MockedPeersViewModule extends AbstractModule {
-  private final ImmutableMap<ECPublicKey, ImmutableList<ECPublicKey>> peersByNodeOrNull;
+  private final ImmutableMap<ECPublicKey, ImmutableList<ECPublicKey>> peersByNode;
 
   /**
-   * @param peersByNodeOrNull - If passed a null map, then each node is assumed to have each other node as a peer.
+   * @param peersByNodeOrNull - If passed a null map, then each node is assumed to have each other
+   *     node as a peer.
    */
   public MockedPeersViewModule(
       ImmutableMap<ECPublicKey, ImmutableList<ECPublicKey>> peersByNodeOrNull) {
-    this.peersByNodeOrNull = peersByNodeOrNull;
+    this.peersByNode = peersByNodeOrNull != null ? peersByNodeOrNull : ImmutableMap.of();
   }
 
   @Provides
   public PeersView peersView(@Self BFTNode self, ImmutableList<BFTNode> allNodes) {
     final var peersForNode =
-        peersByNodeOrNull != null && peersByNodeOrNull.containsKey(self.getKey())
-            ? peersByNodeOrNull // Use a specific set of peers for the given node, if defined
+        peersByNode.containsKey(self.getKey())
+            ? peersByNode // Use a specific set of peers for the given node, if defined
                 .get(self.getKey())
                 .stream()
                 .map(BFTNode::create)
@@ -101,8 +102,9 @@ public class MockedPeersViewModule extends AbstractModule {
             .map(PeersView.PeerInfo::fromBftNode)
             .collect(ImmutableList.toImmutableList());
 
-    // PeersView is a functional interface, so we're actually returning an implementation of PeersView.peers
-    // To avoid exceptions from multiple iterations of a stream, each call to PeersView.peers returns a new stream
+    // PeersView is a functional interface, so we're actually returning an implementation of
+    // PeersView.peers. To avoid exceptions from multiple iterations of a stream,
+    // each call to PeersView.peers returns a new stream
     return peersForNodeWithoutSelf::stream;
   }
 }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/Forks.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/Forks.java
@@ -315,7 +315,8 @@ public final class Forks {
     final var candidateFork = maybeCandidateFork.get();
     final var candidateForkId = CandidateForkVote.candidateForkId(candidateFork);
 
-    final var fromEpoch = Math.max(0, candidateFork.minEpoch() - candidateFork.longestThresholdEpochs());
+    final var fromEpoch =
+        Math.max(0, candidateFork.minEpoch() - candidateFork.longestThresholdEpochs());
     final var toEpoch =
         candidateFork.maxEpoch() + 1 < candidateFork.maxEpoch() // Check for overflows
             ? Long.MAX_VALUE


### PR DESCRIPTION
Lots of integration tests were erroring with a Null Reference error, due to missing an explicit peers map.