### PR TITLE
Fix releasenet fork info

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/modules/ReleasenetForksModule.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/modules/ReleasenetForksModule.java
@@ -93,7 +93,7 @@ public final class ReleasenetForksModule extends AbstractModule {
   @ProvidesIntoSet
   ForkBuilder releasenetGenesis() {
     return new ForkBuilder(
-        "releasenet-genesis",
+        "rlsnet-genesis",
         0L,
         RERulesVersion.OLYMPIA_V1,
         new RERulesConfig(
@@ -126,8 +126,8 @@ public final class ReleasenetForksModule extends AbstractModule {
   @ProvidesIntoSet
   ForkBuilder releasenetV2() {
     return new ForkBuilder(
-        "releasenet-v2",
-        7914L,
+        "rlsnet-v2",
+        8809L,
         RERulesVersion.OLYMPIA_V1,
         new RERulesConfig(
             RESERVED_SYMBOLS,


### PR DESCRIPTION
This is to make ReleaseNet compatible with the latest main branch.

The fork names are shortened due to
```
Caused by: java.lang.IllegalArgumentException: Fork name can't be longer than 16 bytes
```