### PR TITLE
Add mainnet candidate fork olympia-rpf-001

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/modules/MainnetForksModule.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/modules/MainnetForksModule.java
@@ -66,6 +66,7 @@ package com.radixdlt.statecomputer.forks.modules;
 
 import static com.radixdlt.constraintmachine.REInstruction.REMicroOp.MSG;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.radixdlt.application.system.FeeTable;
@@ -78,6 +79,7 @@ import com.radixdlt.application.validators.state.ValidatorFeeCopy;
 import com.radixdlt.application.validators.state.ValidatorMetaData;
 import com.radixdlt.application.validators.state.ValidatorOwnerCopy;
 import com.radixdlt.application.validators.state.ValidatorRegisteredCopy;
+import com.radixdlt.statecomputer.forks.CandidateForkConfig;
 import com.radixdlt.statecomputer.forks.ForkBuilder;
 import com.radixdlt.statecomputer.forks.RERulesConfig;
 import com.radixdlt.statecomputer.forks.RERulesVersion;
@@ -151,6 +153,47 @@ public final class MainnetForksModule extends AbstractModule {
             Amount.ofTokens(90), // Minimum stake
             500, // Two weeks worth of epochs
             Amount.ofMicroTokens(2307700), // 2.3077XRD Rewards per proposal
+            9800, // 98.00% threshold for completed proposals to get any rewards
+            100, // 100 max validators
+            MSG.maxLength()));
+  }
+
+  @ProvidesIntoSet
+  ForkBuilder olympiaRadixProtocolFork1() {
+    return new ForkBuilder(
+        "olympia-rpf-001",
+        ImmutableSet.of(new CandidateForkConfig.Threshold((short) 8500, 320)),
+        14493,
+        15224,
+        RERulesVersion.OLYMPIA_V1,
+        new RERulesConfig(
+            RESERVED_SYMBOLS,
+            Pattern.compile("[a-z0-9]+"), // Token symbol pattern
+            FeeTable.create(
+                Amount.ofNanoTokens(116400), // 0.0001164XRD per byte fee
+                Map.of(
+                    TokenResource.class, Amount.ofMilliTokens(58220), // 58.22XRD per resource
+                    ValidatorRegisteredCopy.class,
+                        Amount.ofMilliTokens(2911), // 2.911XRD per validator update
+                    ValidatorFeeCopy.class,
+                        Amount.ofMilliTokens(2911), // 2.911XRD per register update
+                    ValidatorOwnerCopy.class,
+                        Amount.ofMilliTokens(2911), // 2.911XRD per register update
+                    ValidatorMetaData.class,
+                        Amount.ofMilliTokens(2911), // 2.911XRD per register update
+                    AllowDelegationFlag.class,
+                        Amount.ofMilliTokens(2911), // 2.911XRD per register update
+                    PreparedStake.class, Amount.ofMicroTokens(291100), // 0.2911XRD per stake
+                    PreparedUnstakeOwnership.class,
+                        Amount.ofMicroTokens(291100) // 0.2911XRD per unstake
+                    )),
+            (long) 1024 * 1024, // 1MB max user transaction size
+            OptionalInt.of(50), // 50 Txns per round
+            10_000, // Rounds per epoch
+            500, // Two weeks worth of epochs
+            Amount.ofTokens(90), // 90XRD Minimum stake
+            500, // Two weeks worth of epochs
+            Amount.ofMilliTokens(1797), // 1.797XRD Rewards per proposal
             9800, // 98.00% threshold for completed proposals to get any rewards
             100, // 100 max validators
             MSG.maxLength()));

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/modules/MainnetForksModule.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/modules/MainnetForksModule.java
@@ -190,9 +190,9 @@ public final class MainnetForksModule extends AbstractModule {
             (long) 1024 * 1024, // 1MB max user transaction size
             OptionalInt.of(50), // 50 Txns per round
             10_000, // Rounds per epoch
-            500, // Two weeks worth of epochs
+            500, // Validator fee increases take effect after 500 epochs (roughly two weeks)
             Amount.ofTokens(90), // 90XRD Minimum stake
-            500, // Two weeks worth of epochs
+            500, // Unstakes are unlocked after 500 epochs without changes (roughly two weeks)
             Amount.ofMilliTokens(1797), // 1.797XRD Rewards per proposal
             9800, // 98.00% threshold for completed proposals to get any rewards
             100, // 100 max validators

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/modules/ReleasenetForksModule.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/modules/ReleasenetForksModule.java
@@ -66,6 +66,7 @@ package com.radixdlt.statecomputer.forks.modules;
 
 import static com.radixdlt.constraintmachine.REInstruction.REMicroOp.MSG;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.radixdlt.application.system.FeeTable;
@@ -78,6 +79,7 @@ import com.radixdlt.application.validators.state.ValidatorFeeCopy;
 import com.radixdlt.application.validators.state.ValidatorMetaData;
 import com.radixdlt.application.validators.state.ValidatorOwnerCopy;
 import com.radixdlt.application.validators.state.ValidatorRegisteredCopy;
+import com.radixdlt.statecomputer.forks.CandidateForkConfig;
 import com.radixdlt.statecomputer.forks.ForkBuilder;
 import com.radixdlt.statecomputer.forks.RERulesConfig;
 import com.radixdlt.statecomputer.forks.RERulesVersion;
@@ -152,6 +154,47 @@ public final class ReleasenetForksModule extends AbstractModule {
             500, // Two weeks worth of epochs
             Amount.ofMicroTokens(2307700), // Rewards per proposal
             9800, // 98.00% threshold for completed proposals to get any rewards,
+            100, // 100 max validators
+            MSG.maxLength()));
+  }
+
+  @ProvidesIntoSet
+  ForkBuilder olympiaRadixProtocolFork1() {
+    return new ForkBuilder(
+        "rlsnet-rpf-001",
+        ImmutableSet.of(new CandidateForkConfig.Threshold((short) 8500, 2)),
+        11420,
+        15000,
+        RERulesVersion.OLYMPIA_V1,
+        new RERulesConfig(
+            RESERVED_SYMBOLS,
+            Pattern.compile("[a-z0-9]+"), // Token symbol pattern
+            FeeTable.create(
+                Amount.ofNanoTokens(116400), // 0.0001164XRD per byte fee
+                Map.of(
+                    TokenResource.class, Amount.ofMilliTokens(58220), // 58.22XRD per resource
+                    ValidatorRegisteredCopy.class,
+                        Amount.ofMilliTokens(2911), // 2.911XRD per validator update
+                    ValidatorFeeCopy.class,
+                        Amount.ofMilliTokens(2911), // 2.911XRD per register update
+                    ValidatorOwnerCopy.class,
+                        Amount.ofMilliTokens(2911), // 2.911XRD per register update
+                    ValidatorMetaData.class,
+                        Amount.ofMilliTokens(2911), // 2.911XRD per register update
+                    AllowDelegationFlag.class,
+                        Amount.ofMilliTokens(2911), // 2.911XRD per register update
+                    PreparedStake.class, Amount.ofMicroTokens(291100), // 0.2911XRD per stake
+                    PreparedUnstakeOwnership.class,
+                        Amount.ofMicroTokens(291100) // 0.2911XRD per unstake
+                    )),
+            (long) 1024 * 1024, // 1MB max user transaction size
+            OptionalInt.of(50), // 50 Txns per round
+            10_000, // Rounds per epoch
+            500, // Two weeks worth of epochs
+            Amount.ofTokens(90), // 90XRD Minimum stake
+            500, // Two weeks worth of epochs
+            Amount.ofMilliTokens(1797), // 1.797XRD Rewards per proposal
+            9800, // 98.00% threshold for completed proposals to get any rewards
             100, // 100 max validators
             MSG.maxLength()));
   }

--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/modules/ReleasenetForksModule.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/modules/ReleasenetForksModule.java
@@ -190,9 +190,9 @@ public final class ReleasenetForksModule extends AbstractModule {
             (long) 1024 * 1024, // 1MB max user transaction size
             OptionalInt.of(50), // 50 Txns per round
             10_000, // Rounds per epoch
-            500, // Two weeks worth of epochs
+            500, // Validator fee increases take effect after 500 epochs (roughly two weeks)
             Amount.ofTokens(90), // 90XRD Minimum stake
-            500, // Two weeks worth of epochs
+            500, // Unstakes are unlocked after 500 epochs without changes (roughly two weeks)
             Amount.ofMilliTokens(1797), // 1.797XRD Rewards per proposal
             9800, // 98.00% threshold for completed proposals to get any rewards
             100, // 100 max validators

--- a/radixdlt-engine/src/main/java/com/radixdlt/application/tokens/Amount.java
+++ b/radixdlt-engine/src/main/java/com/radixdlt/application/tokens/Amount.java
@@ -90,6 +90,11 @@ public final class Amount {
         UInt256.from(units).multiply(UInt256.TEN.pow(TokenUtils.SUB_UNITS_POW_10 - 6)));
   }
 
+  public static Amount ofNanoTokens(long units) {
+    return new Amount(
+        UInt256.from(units).multiply(UInt256.TEN.pow(TokenUtils.SUB_UNITS_POW_10 - 9)));
+  }
+
   public static Amount ofTokens(long units) {
     return new Amount(UInt256.from(units).multiply(TokenUtils.SUB_UNITS));
   }


### PR DESCRIPTION
As per the [published policy](https://learn.radixdlt.com/article/what-is-the-current-policy-for-fee-emissions-updates) and [blog post](https://www.radixdlt.com/post/planned-updates-to-radix-network-fees-and-emissions), this adds the first Radix Protocol Fork 001.

## Fork Parameters

This was calculated with:
* 30 Day SMA Epoch Length: 00:31:30
* 7 Day XRD Price SMA: $0.066992

For comparison, the original Olympia Fee Table was calculated with an effective:
* Epoch Length: 00:40:27
* XRD Price: $0.039

The epochs are chosen such that:
* The earliest possible fork is at epoch 14493 (approx Mon 2022-07-11 at 13:10:48 UTC)
* The latest possible fork is at epoch 15224 (approx Wed 2022-07-27 at 12:57:18 UTC)

The enactment thresholds are as follows:
* Once validators with at least 85% of the active voting power show readiness for the fork, if this threshold is maintained for 320 epochs (roughly 7D 0H 1M 0S), and the epoch is within the allowable fork range above; then the fork will enact.

Future Radix Protocol Forks will come with a more detailed set of enactment thresholds, but with some nodes not yet running 1.22, the decision was made to opt for a simpler threshold for this first fork, which should give us approximately a week of certainty about the fork epoch.
