### PR TITLE
Remove the radixdlt/radixdlt-nginx dispatch event from releases

### DIFF
--- a/.github/workflows/release-created.yml
+++ b/.github/workflows/release-created.yml
@@ -23,25 +23,6 @@ jobs:
               "release_job_url": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
               "is_prerelease": "${{ github.event.release.prerelease }}"
             }
-  start_radixdlt_nginx_release:
-    name: Start radixdlt-nginx release ${{ github.event.release.tag_name }}
-    runs-on: ubuntu-latest
-    environment: publish-artifacts
-    steps:
-      - name: Trigger radixdlt/radixdlt-nginx release ${{ github.event.release.tag_name }}
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.RADIXBOT_GITHUB_REPO_PACKAGES_TOKEN }}
-          repository: radixdlt/radixdlt-nginx
-          event-type: start_release
-          client-payload: |
-            {
-              "ref": "${{ github.ref }}",
-               "release_tag": "${{ github.event.release.tag_name }}",
-               "release_url": "${{ github.event.release.html_url }}",
-               "release_job_url": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-               "is_prerelease": "${{ github.event.release.prerelease }}"
-            }
   start_radixdlt_node_runner:
     name: Start node-runner release ${{ github.event.release.tag_name }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
The nginx repo might deviate from the node so we won't be using this event.