### PR TITLE
NODE-393 - olympia-rpf-001 fixed at epoch 14493

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/modules/MainnetForksModule.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/statecomputer/forks/modules/MainnetForksModule.java
@@ -66,7 +66,6 @@ package com.radixdlt.statecomputer.forks.modules;
 
 import static com.radixdlt.constraintmachine.REInstruction.REMicroOp.MSG;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.radixdlt.application.system.FeeTable;
@@ -79,7 +78,6 @@ import com.radixdlt.application.validators.state.ValidatorFeeCopy;
 import com.radixdlt.application.validators.state.ValidatorMetaData;
 import com.radixdlt.application.validators.state.ValidatorOwnerCopy;
 import com.radixdlt.application.validators.state.ValidatorRegisteredCopy;
-import com.radixdlt.statecomputer.forks.CandidateForkConfig;
 import com.radixdlt.statecomputer.forks.ForkBuilder;
 import com.radixdlt.statecomputer.forks.RERulesConfig;
 import com.radixdlt.statecomputer.forks.RERulesVersion;
@@ -162,9 +160,7 @@ public final class MainnetForksModule extends AbstractModule {
   ForkBuilder olympiaRadixProtocolFork1() {
     return new ForkBuilder(
         "olympia-rpf-001",
-        ImmutableSet.of(new CandidateForkConfig.Threshold((short) 8500, 320)),
         14493,
-        15224,
         RERulesVersion.OLYMPIA_V1,
         new RERulesConfig(
             RESERVED_SYMBOLS,


### PR DESCRIPTION
Follows on from https://github.com/radixdlt/radixdlt/pull/702

As per the [published policy](https://learn.radixdlt.com/article/what-is-the-current-policy-for-fee-emissions-updates) and [blog post](https://www.radixdlt.com/post/planned-updates-to-radix-network-fees-and-emissions), this PR relates to the first Radix Protocol Fork 001.

This PR assumes that the vote threshold will be maintained. As such, it will only be released once we are sufficiently certain that the fork will go ahead at this epoch.