### PR TITLE
fix: use the first 11 symbol character for RRI HRP

### DIFF
--- a/radixdlt-java-common/src/main/java/com/radixdlt/identifiers/ResourceAddressing.java
+++ b/radixdlt-java-common/src/main/java/com/radixdlt/identifiers/ResourceAddressing.java
@@ -130,6 +130,7 @@ public final class ResourceAddressing {
   public String of(String symbol, REAddr addr) {
     var addrBytes = addr.getBytes();
     var bech32Data = toBech32Data(addrBytes);
-    return Bech32.encode(symbol + hrpSuffix, bech32Data);
+    var shortSymbol = symbol.substring(0, Math.min(symbol.length(), 11));
+    return Bech32.encode(shortSymbol + hrpSuffix, bech32Data);
   }
 }

--- a/radixdlt-java-common/src/test/java/com/radixdlt/identifiers/ResourceAddressingTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/identifiers/ResourceAddressingTest.java
@@ -81,9 +81,12 @@ public class ResourceAddressingTest {
   private final BiMap<Pair<String, String>, String> reAddressToRri =
       HashBiMap.create(
           Map.of(
-              Pair.of("xrd", "01"), "xrd_rb1qya85pwq",
+              Pair.of("xrd", "01"),
+              "xrd_rb1qya85pwq",
+              Pair.of("toolongsymbol", "0352d50f521da177cc14e22486e9af189e76f6b60520f766f3e663"),
+              "toolongsymbol_rb1qdfd2r6jrksh0nq5ugjgd6d0rz08da4kq5s0wehnue3s84p3re",
               Pair.of("usdc", "03" + "00".repeat(26)),
-                  "usdc_rb1qvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gwwwd"));
+              "usdc_rb1qvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gwwwd"));
 
   private final Map<String, String> invalidRris =
       Map.of(

--- a/radixdlt-java-common/src/test/java/com/radixdlt/identifiers/ResourceAddressingTest.java
+++ b/radixdlt-java-common/src/test/java/com/radixdlt/identifiers/ResourceAddressingTest.java
@@ -78,13 +78,21 @@ import org.junit.Test;
 
 public class ResourceAddressingTest {
   private final ResourceAddressing resourceAddressing = ResourceAddressing.bech32("_rb");
+
+  private final Map<Pair<String, String>, String> reAddressToRriShortened =
+      Map.of(
+          Pair.of("toolongsymbol", "03925a206b9d3d7513e145a4b42741ac22c7d081ffc511420e4e43"),
+          "toolongsymb",
+          Pair.of("anotherlongsymbol", "03a3442075945d7513e169a4b42741ac22c7d081ffc511420e4e43"),
+          "anotherlong");
+
   private final BiMap<Pair<String, String>, String> reAddressToRri =
       HashBiMap.create(
           Map.of(
               Pair.of("xrd", "01"),
               "xrd_rb1qya85pwq",
-              Pair.of("toolongsymbol", "0352d50f521da177cc14e22486e9af189e76f6b60520f766f3e663"),
-              "toolongsymbol_rb1qdfd2r6jrksh0nq5ugjgd6d0rz08da4kq5s0wehnue3s84p3re",
+              Pair.of("toolongsymb", "0352d50f521da177cc14e22486e9af189e76f6b60520f766f3e663"),
+              "toolongsymb_rb1qdfd2r6jrksh0nq5ugjgd6d0rz08da4kq5s0wehnue3sxzch2j",
               Pair.of("usdc", "03" + "00".repeat(26)),
               "usdc_rb1qvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gwwwd"));
 
@@ -117,6 +125,15 @@ public class ResourceAddressingTest {
           var reAddr = REAddr.of(Bytes.fromHexString(pair.getSecond()));
           var rri = resourceAddressing.of(pair.getFirst(), reAddr);
           assertThat(expected).isEqualTo(rri);
+        });
+
+    reAddressToRriShortened.forEach(
+        (pair, truncatedSymbol) -> {
+          var longSymbol = pair.getFirst();
+          var reAddr = REAddr.of(Bytes.fromHexString(pair.getSecond()));
+
+          assertThat(resourceAddressing.of(longSymbol, reAddr))
+              .isEqualTo(resourceAddressing.of(truncatedSymbol, reAddr));
         });
   }
 


### PR DESCRIPTION
See also: https://github.com/radixdlt/radixdlt-network-gateway/pull/73

References: jira NG-158