### PR TITLE
Increase MAX_PACKET_LENGTH and RECEIVE_BUFFER_SIZE to 5 MiB

### DIFF
--- a/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannelInitializer.java
+++ b/radixdlt-core/radixdlt/src/main/java/com/radixdlt/network/p2p/transport/PeerChannelInitializer.java
@@ -95,9 +95,9 @@ import org.apache.logging.log4j.Logger;
 public final class PeerChannelInitializer extends ChannelInitializer<SocketChannel> {
   private static final Logger log = LogManager.getLogger();
 
-  private static final int MAX_PACKET_LENGTH = 1024 * 1024;
+  private static final int MAX_PACKET_LENGTH = 5 * 1024 * 1024;
   private static final int FRAME_HEADER_LENGTH = Integer.BYTES;
-  private static final int RECEIVE_BUFFER_SIZE = 1024 * 1024;
+  private static final int RECEIVE_BUFFER_SIZE = 5 * 1024 * 1024;
   private static final int SOCKET_BACKLOG_SIZE = 1024;
 
   private final P2PConfig config;


### PR DESCRIPTION
This specifically allows processing large ledger sync responses.